### PR TITLE
Add Reset Button for Site Creation Error and Enhance Error Messaging

### DIFF
--- a/admin/templates/partials/error-message.php
+++ b/admin/templates/partials/error-message.php
@@ -2,17 +2,9 @@
 	<div class="flex items-center gap-2.5">
 		<img src="<?php echo esc_url(PCC_PLUGIN_DIR_URL . 'assets/images/diamond-exclamation.png') ?>"
 			 alt="Diamond exclamation icon">
-		<p id="pcc-error-text" class="text-sm text-black"></p>
+		<div id="pcc-error-text"></div>
 	</div>
 	<div class="flex items-center gap-4">
-<!--		<div>-->
-<!--			<a class="secondary-button" href="">--><?php
-//				esc_html_e(
-//					'Action',
-//					PCC_HANDLE
-//				)
-//				?><!--</a>-->
-<!--		</div>-->
 		<button id="pcc-error-close-button">
 			<img src="<?php echo esc_url(PCC_PLUGIN_DIR_URL . 'assets/images/close-icon.png') ?>"
 				 alt="Close icon">

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,4 +1,4 @@
-import {deleteConfigDetails, redirectToMainPage} from "./helper";
+import {deleteConfigDetails, PccDisconnect, redirectToMainPage} from "./helper";
 import createSite from "./createSite";
 import {hideErrorMessage, hideSpinner, showErrorMessage, showSpinner, updateSpinnerText} from "./helper";
 import updatePostType from "./updatePostType";
@@ -24,7 +24,10 @@ if (document.getElementById('pcc-create-site') != undefined) {
 			await createSite();
 			redirectToMainPage();
 		} catch (error) {
-			showErrorMessage(`Error while creating site: ${error.message}`)
+			showErrorMessage([
+				`Error while creating site: ${error.response.data}`,
+				'Your management token might be restricted or you might have to tried to authenticate with a gmail.com account'
+			], true)
 			hideSpinner();
 		}
 	});
@@ -36,24 +39,14 @@ if (document.getElementById('pcc-update-collection') != undefined) {
 			await updatePostType();
 			redirectToMainPage();
 		} catch (error) {
-			showErrorMessage(`Error while creating site: ${error.message}`)
+			showErrorMessage(`Error while creating site: ${error.response.data}`)
 		} finally {
 		}
 	});
 }
 
 if (document.getElementById('pcc-disconnect') != undefined) {
-	document.getElementById('pcc-disconnect').addEventListener('click', async function () {
-		try {
-			showSpinner();
-			updateSpinnerText('Disconnecting your collection...')
-			await deleteConfigDetails();
-			redirectToMainPage();
-		} catch (error) {
-			showErrorMessage(`Error while disconnecting: ${error.message}`)
-			hideSpinner();
-		}
-	});
+	document.getElementById('pcc-disconnect').addEventListener('click', PccDisconnect);
 }
 
 if (document.getElementById('pcc-error-close-button') != undefined) {

--- a/assets/js/helper.js
+++ b/assets/js/helper.js
@@ -48,11 +48,32 @@ export function getAccessToken() {
  * Show error message
  * @param message
  */
-export function showErrorMessage(message) {
+export function showErrorMessage(messages, showResetLink = false) {
 	const errorMessageContainer = document.getElementById('pcc-error-message');
 	const errorText = document.getElementById('pcc-error-text');
+	if(typeof messages === 'string') {
+		messages = [messages];
+	}
 	if (errorMessageContainer && errorText) {
-		errorText.textContent = message || 'Error:please try again later';
+		errorText.innerHTML = '';
+		for (let index in messages) {
+			if (index !== "0") {
+				errorText.appendChild(document.createElement("br"));
+			}
+			let pTag = document.createElement("p");
+			pTag.className = "text-sm text-black";
+			pTag.textContent = messages[index];
+			errorText.appendChild(pTag);
+		}
+		if (showResetLink) {
+			let resetLink = document.createElement("a");
+			resetLink.className = "text-red-600 font-semibold";
+			resetLink.textContent = 'Click here to reset Google Workspace authentication.';
+			resetLink.id = 'pcc-disconnect';
+			resetLink.href = '#';
+			resetLink.onclick = PccDisconnect;
+			errorText.appendChild(resetLink);
+		}
 		errorMessageContainer.classList.remove('hidden');
 	}
 }
@@ -87,3 +108,15 @@ export const deleteConfigDetails = async () => {
 
 	return resp
 };
+
+export const PccDisconnect = async () => {
+	try {
+		showSpinner();
+		updateSpinnerText('Disconnecting your collection...')
+		await deleteConfigDetails();
+		redirectToMainPage();
+	} catch (error) {
+		showErrorMessage(`Error while disconnecting: ${error.response.data}`)
+		hideSpinner();
+	}
+}


### PR DESCRIPTION
## Description

This pull request introduces a reset button that appears when users are unable to create a site. The reset button allows users to reset their Google Workspace authentication. Additionally, the error messaging system has been enhanced to support multiple error messages and provide a clearer user experience.

## Testing instructions

<!-- Add instructions to help the reviewer test your code. -->
<!-- Include sample forms, add-ons or snippets where appropriate. -->

## Screenshots

[screencast-pantheon.xyz-2024.08.05-18_08_34.webm](https://github.com/user-attachments/assets/4eb52a15-1b81-4af9-b6b8-fa89c520ee3f)


## Checklist:

- [x] I've tested the code.
- [x] My code follows the repository code
  style. <!-- Ruleset: https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress/blob/primary/phpcs.xml/ -->
- [x] My code follows the accessibility
  standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code follows the PHP DocBlock documentation
  standards. <!-- Resource: https://docs.phpdoc.org/guides/docblocks.html -->
