### PR TITLE
Feature | Unlock the Native WordPress Editor

### DIFF
--- a/app/Settings.php
+++ b/app/Settings.php
@@ -83,7 +83,6 @@ class Settings
 		add_action('admin_menu', [$this, 'pluginAdminNotice']);
 		add_filter('post_row_actions', [$this, 'addRowActions'], 10, 2);
 		add_filter('page_row_actions', [$this, 'addRowActions'], 10, 2);
-		add_action('admin_init', [$this, 'preventPostEditing']);
 		add_filter('wp_list_table_class_name', [$this, 'overrideAdminWPPostsTable']);
 		add_filter('the_content', [$this, 'addPreviewContainer']);
 		add_filter('admin_init', [$this, 'verifyCollectionUrl']);
@@ -239,28 +238,6 @@ class Settings
 	}
 
 	/**
-	 * Prevent editing of PCC posts.
-	 *
-	 * @return void
-	 */
-	public function preventPostEditing(): void
-	{
-		global $pagenow;
-		// Check if the current page is the post/page edit page
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		if ($pagenow == 'post.php' && isset($_GET['post']) && 'edit' === strtolower($_GET['action'])) {
-			// phpcs:ignore
-			$documentId = get_post_meta(intval($_GET['post']), PCC_CONTENT_META_KEY, true);
-			if (!$documentId) {
-				return;
-			}
-
-			wp_redirect($this->buildEditDocumentURL($documentId));
-			die(200);
-		}
-	}
-
-	/**
 	 * Build the Google Docs edit URL.
 	 *
 	 * @param string $documentId
@@ -327,10 +304,6 @@ class Settings
 		);
 
 		$actions = array_merge($customActions, $actions);
-
-		if (isset($actions['edit'])) {
-			unset($actions['edit']);
-		}
 
 		if (isset($actions['inline hide-if-no-js'])) {
 			unset($actions['inline hide-if-no-js']);


### PR DESCRIPTION
## Description

The previous implementation restricted editing for posts synchronized by the PCC, removing the editing link and disabling the WordPress editor for such content. The refactor involves reverting these restrictions, allowing the editing link to reappear and removing the limitations on editing PCC-synchronized posts. This change improves flexibility, enabling users to modify content as needed.

## Testing instructions

1. **Test 1: Restore Editing Link**
   * Verify that the editing link is visible for posts that were previously restricted by PCC synchronization.
   * Confirm that clicking the link redirects to the WordPress editor.
2. **Test 2: Remove Editing Restrictions**
   * Check that the WordPress editor is fully functional for PCC-synchronized content.
   * Ensure that users can make and save changes without encountering previous restrictions.

## Screenshots
![image](https://github.com/user-attachments/assets/9799531b-724e-4992-bc95-c71dedcf6494)


## Checklist:

- [X] I've tested the code.
- [X] My code follows the repository code
  style. <!-- Ruleset: https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress/blob/primary/phpcs.xml/ -->
- [ ] My code follows the accessibility
  standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code follows the PHP DocBlock documentation
  standards. <!-- Resource: https://docs.phpdoc.org/guides/docblocks.html -->
