### PR TITLE
Feature/comptability metatags

### DIFF
--- a/app/PccSyncManager.php
+++ b/app/PccSyncManager.php
@@ -116,12 +116,27 @@ class PccSyncManager
 		if (!$postId) {
 			$postId = wp_insert_post($data);
 			update_post_meta($postId, PCC_CONTENT_META_KEY, $article->id);
+			$this->updatePostTags($postId, $article);
 			return $postId;
 		}
 
 		$data['ID'] = $postId;
 		wp_update_post($data);
+		$this->updatePostTags($postId, $article);
 		return $postId;
+	}
+
+	/**
+	 * Update post tags.
+	 *
+	 * @param $postId
+	 * @param Article $article
+	 */
+	private function updatePostTags($postId, Article $article): void
+	{
+		if (isset($article->tags) && is_array($article->tags)) {
+			wp_set_post_terms($postId, $article->tags, 'post_tag', false);
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Description

**Summary:** This update focuses on synchronizing content in WordPress by fetching and correctly mapping tags from PCC as content tags.

**Details:** When publishing or updating content via PCC, the system will now correctly fetch the "Tags" metadata and map it to the corresponding content tags in WordPress. This ensures that the tags associated with the content in PCC are accurately reflected in the WordPress environment.

## Testing instructions

1. **Test 1:** Validate that tags are correctly fetched from PCC during content synchronization.
2. **Test 2:** Confirm that the tags are accurately mapped and displayed in WordPress when content is published or updated.
3. **Test 3:** Ensure that PCC tags overwrite post tags on update.
4. **Test 4:** Ensure that if tag is already exist not duplicating the tag and use the already exist one .

## Screenshots

1. Wordpress 
![image](https://github.com/user-attachments/assets/29dfab10-b4c7-4b6f-a365-dc890a97e737)
2. PCC Addon
![image](https://github.com/user-attachments/assets/ea8c928b-383c-4f17-b7f5-66f1c47f3b4b)


## Checklist:

- [x] I've tested the code.
- [x] My code follows the repository code
  style. <!-- Ruleset: https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress/blob/primary/phpcs.xml/ -->
- [x] My code follows the accessibility
  standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the PHP DocBlock documentation
  standards. <!-- Resource: https://docs.phpdoc.org/guides/docblocks.html -->
