### PR TITLE
PCC-1494 : adding backstage info, github action and codeowners files

### DIFF
--- a/.github/workflows/catalog.yml
+++ b/.github/workflows/catalog.yml
@@ -1,0 +1,17 @@
+---
+name: Catalog
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - primary
+permissions:
+  contents: "read"
+  packages: "read"
+  id-token: "write"
+jobs:
+  docs:
+    uses: pantheon-systems/service-catalog/.github/workflows/docs-like-code.yaml@main
+  catalog-upload:
+    uses: pantheon-systems/service-catalog/.github/workflows/catalog-upload.yaml@main

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+# Ref : https://github.com/dotnet/samples/blob/main/.github/CODEOWNERS
+
+# PCX development team.
+* @pantheon-systems/pcc

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# PCC Wordpress Publisher
+
 <p align="center">
   <a target="_blank" href="https://pcc.pantheon.io/">
     <img src="assets/images/pantheon-fist-logo.svg" alt="Plugin Logo" width="72" height="72">

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -4,7 +4,7 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: pantheon content wordpress publisher
+  name: pantheon-content-wordpress-publisher
   description: A PCC publisher module for publishing wordpress content
   annotations:
     pantheon.io/service-catalog/subdir: /

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,19 @@
+# https://backstage.io/docs/features/software-catalog/
+# https://backstage.io/docs/features/software-catalog/descriptor-format
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: pantheon content wordpress publisher
+  description: A PCC publisher module for publishing wordpress content
+  annotations:
+    backstage.io/techdocs-ref: dir:docs/
+    github.com/project-slug: @pantheon-systems/pantheon-content-publisher-for-wordpress
+    github.com/team-slug: @pantheon-systems/pcc
+tags:
+    - laravel
+      php
+spec:
+  type: library
+  lifecycle: Introduction
+  owner: content-cloud

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -7,7 +7,7 @@ metadata:
   name: pantheon content wordpress publisher
   description: A PCC publisher module for publishing wordpress content
   annotations:
-    backstage.io/techdocs-ref: dir:docs/
+    pantheon.io/service-catalog/subdir: /
     github.com/project-slug: @pantheon-systems/pantheon-content-publisher-for-wordpress
     github.com/team-slug: @pantheon-systems/pcc
 tags:

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -8,11 +8,8 @@ metadata:
   description: A PCC publisher module for publishing wordpress content
   annotations:
     pantheon.io/service-catalog/subdir: /
-    github.com/project-slug: @pantheon-systems/pantheon-content-publisher-for-wordpress
-    github.com/team-slug: @pantheon-systems/pcc
-tags:
-    - laravel
-      php
+    github.com/project-slug: pantheon-systems/pantheon-content-publisher-for-wordpress
+    github.com/team-slug: pantheon-systems/pcc
 spec:
   type: library
   lifecycle: Introduction


### PR DESCRIPTION
I am creating codeowners and catalog-info files. details can be found at https://getpantheon.atlassian.net/browse/PCC-1494