### PR TITLE
Add disableWpautopForPCPPosts method to prevent wpautop filter on PCP posts

### DIFF
--- a/app/PccSyncManager.php
+++ b/app/PccSyncManager.php
@@ -117,19 +117,12 @@ class PccSyncManager
 		// Original content
 		$content = $article->content;
 
-		// Regular expression to match all <style>...</style> blocks
-		$pattern = '/<style.*?>.*?<\/style>/is';
+		// Pattern to match all <style> blocks
+		$stylePattern = '/<style.*?>.*?<\/style>/is';
 
-		// Find all <style> blocks
-		preg_match_all($pattern, $content, $matches);
+		// Remove all <style> blocks from the content
+		$content = preg_replace($stylePattern, '', $content);
 
-		// Remove all <style> blocks from the original content
-		$content = preg_replace($pattern, '', $content);
-
-		// Concatenate all <style> blocks at the end
-		foreach ($matches[0] as $styleBlock) {
-			$content .= $styleBlock;
-		}
 		$data = [
 			'post_title' => $article->title,
 			'post_content' => $content,

--- a/app/Settings.php
+++ b/app/Settings.php
@@ -71,7 +71,6 @@ class Settings
 	{
 		add_action('template_redirect', [$this, 'registerPantheonCloudStatusEndpoint']);
 		add_action('template_redirect', [$this, 'publishDocuments']);
-		add_action('template_redirect', [$this, 'disableWpautopForPCPPosts']);
 		add_action('admin_menu', [$this, 'addMenu']);
 		add_action(
 			'admin_enqueue_scripts',
@@ -236,19 +235,6 @@ class Settings
 			}
 		} catch (Exception $ex) {
 			// No Action needed for safe exit
-		}
-	}
-
-	/**
-	 * Disable wpautop for PCP posts.
-	 *
-	 * @return void
-	 */
-	public function disableWpautopForPCPPosts(): void
-	{
-		if (is_singular() && get_post_meta(get_the_ID(), PCC_CONTENT_META_KEY, true)) {
-			remove_filter('the_content', 'wpautop');
-			remove_filter('the_excerpt', 'wpautop');
 		}
 	}
 

--- a/app/Settings.php
+++ b/app/Settings.php
@@ -71,6 +71,7 @@ class Settings
 	{
 		add_action('template_redirect', [$this, 'registerPantheonCloudStatusEndpoint']);
 		add_action('template_redirect', [$this, 'publishDocuments']);
+		add_action('template_redirect', [$this, 'disableWpautopForPCPPosts']);
 		add_action('admin_menu', [$this, 'addMenu']);
 		add_action(
 			'admin_enqueue_scripts',
@@ -235,6 +236,19 @@ class Settings
 			}
 		} catch (Exception $ex) {
 			// No Action needed for safe exit
+		}
+	}
+
+	/**
+	 * Disable wpautop for PCP posts.
+	 *
+	 * @return void
+	 */
+	public function disableWpautopForPCPPosts(): void
+	{
+		if (is_singular() && get_post_meta(get_the_ID(), PCC_CONTENT_META_KEY, true)) {
+			remove_filter('the_content', 'wpautop');
+			remove_filter('the_excerpt', 'wpautop');
 		}
 	}
 


### PR DESCRIPTION
## Description

On investigation, I can see that the problem is not with the logic that moves the style tags to the bottom per say. I executed that logic independently on articles which had this issue and found the output to be correct and rendered alright when loaded independently into a browser. The problem, upon searching, seems to be with how the WordPress engine processes and cleans HTML before saving. It seems to wrap some style tags in `<p>` blocks. Its called wpautop People have raised this issue with other tags in a bunch of places:

https://stackoverflow.com/questions/11248628/disable-wordpress-from-adding-p-tags
https://wordpress.org/support/topic/tag-disappears-when-switching-between-text-and-visual-panels/
https://core.trac.wordpress.org/ticket/34722

 There are a bunch of possible fixes:
    1. Disable wpautop for the posts created by Content Publisher
    2. Wrap the <style> tags in a custom shortcode to prevent WordPress from modifying them.
    3. Minify the inline styles by placing them on a single line without extra spaces or line breaks. This reduces the chance of WordPress misinterpreting them.

I am choosing to disable wpautop and it fixed the issue. As per the documentation of this functionality [here](https://developer.wordpress.org/reference/functions/wpautop/), it is just a group of regex replaces used to identify text formatted with newlines and replace double line breaks with HTML paragraph tags. I dont think this is essential for our use case.

## Testing instructions

Just use the latest release of the plugin in a wordpress site, publish a document which had issues before to it and see if its working alright.


## Checklist:

- [*] I've tested the code.
- [*] My code follows the repository code
  style. <!-- Ruleset: https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress/blob/primary/phpcs.xml/ -->
- [)] My code follows the accessibility
  standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [*] My code follows the PHP DocBlock documentation
  standards. <!-- Resource: https://docs.phpdoc.org/guides/docblocks.html -->
