### PR TITLE
[PCC 2132] Improve preview handling

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -51,8 +51,15 @@ All posts/pages created with Pantheon Content Publisher will remain on your Word
 
 == Changelog ==
 = 1.2.3 =
-* Compatibility: Ensure adherence to WP Plugin guidelines
+* Feature: Display collection ID on Connected Content Collection page.
+* Feature: Improve preview request handling.
+* Fix: Disables caching of preview pages.
+* Fix: Correct font size for documentation link text.
+* Fix: Updates "Access token" mention in setup page to "Management token" to more accurately reflect the required token type.
+* Compatibility: Update pcc-sdk-core dependency.
+
 = 1.2.2 =
+* Compatibility: Ensure adherence to WP Plugin guidelines
 * Compatibility: Save <style> tag at the end of post content
 * Stability: Improve edge case handling for PCC articles
 = 1.2.1 =

--- a/app/PccSyncManager.php
+++ b/app/PccSyncManager.php
@@ -38,8 +38,9 @@ class PccSyncManager
 		$documentId,
 		PublishingLevel $publishingLevel,
 		bool $isDraft = false,
+		PccClient $pccClient = null
 	): int {
-		$articlesApi = new ArticlesApi($this->pccClient());
+		$articlesApi = new ArticlesApi($pccClient ?? $this->pccClient());
 		$article = $articlesApi->getArticleById(
 			$documentId,
 			[
@@ -91,7 +92,7 @@ class PccSyncManager
 	 * @param $value
 	 * @return int|null
 	 */
-	public function findExistingConnectedPost($value)
+	public function findExistingConnectedPost($value, $postStatus = null)
 	{
 		$args = [
 			'post_type'   => 'any',
@@ -100,6 +101,11 @@ class PccSyncManager
 			'fields'      => 'ids',
 			'numberposts' => 1,
 		];
+
+		if ($postStatus) {
+			$args['post_status'] = $postStatus;
+		}
+		
 		$posts = get_posts($args);
 		return !empty($posts) ? (int) $posts[0] : null;
 	}
@@ -357,7 +363,6 @@ class PccSyncManager
 		$postId = $postId ?: $this->findExistingConnectedPost($documentId);
 		return add_query_arg(
 			[
-				'preview' => 'google_document',
 				'publishing_level' => PublishingLevel::REALTIME->value,
 				'document_id' => $documentId,
 				'pccGrant' => $pccGrant,

--- a/app/PccSyncManager.php
+++ b/app/PccSyncManager.php
@@ -105,7 +105,7 @@ class PccSyncManager
 		if ($postStatus) {
 			$args['post_status'] = $postStatus;
 		}
-		
+
 		$posts = get_posts($args);
 		return !empty($posts) ? (int) $posts[0] : null;
 	}

--- a/app/PccSyncManager.php
+++ b/app/PccSyncManager.php
@@ -120,31 +120,16 @@ class PccSyncManager
 	 */
 	private function createOrUpdatePost($postId, Article $article, bool $isDraft = false)
 	{
-		// Original content
-		$content = $article->content;
-
-		// Pattern to match all <style> blocks
-		$stylePattern = '/<style.*?>.*?<\/style>/is';
-
-		// Remove all <style> blocks from the content
-		$content = preg_replace($stylePattern, '', $content);
+		$preparedData = $this->preparePostDataFromArticle($article);
 
 		$data = [
-			'post_title' => $article->title,
-			'post_content' => $content,
+			'post_title' => $preparedData['post_title'],
+			'post_content' => $preparedData['post_content'],
+			'post_excerpt' => $preparedData['post_excerpt'],
 			'post_status' => $isDraft ? 'draft' : 'publish',
 			'post_name' => $article->slug,
 			'post_type' => $this->getIntegrationPostType(),
 		];
-		// Set post excerpt if description is available.
-		if (isset($article->metadata['description'])) {
-			$data['post_excerpt'] = $article->metadata['description'];
-		}
-
-		// Set post title if available.
-		if (isset($article->metadata['title']) && $article->metadata['title']) {
-			$data['post_title'] = $article->metadata['title'];
-		}
 
 		if (!$postId) {
 			$postId = wp_insert_post($data);
@@ -419,5 +404,41 @@ class PccSyncManager
 		}
 
 		return false;
+	}
+
+	/**
+	 * Prepare core post data fields from a PCC Article object.
+	 *
+	 * @param Article $article The PCC Article object.
+	 * @return array Associative array with keys 'post_title', 'post_content', 'post_excerpt'.
+	 */
+	public function preparePostDataFromArticle(Article $article): array
+	{
+		// Original content
+		$content = $article->content;
+
+		// Pattern to match all <style> blocks
+		$stylePattern = '/<style.*?>.*?<\/style>/is';
+
+		// Remove all <style> blocks from the content
+		$content = preg_replace($stylePattern, '', $content);
+
+		$data = [
+			'post_content' => $content,
+			'post_title' => $article->title, // Default title
+			'post_excerpt' => '', // Default empty excerpt
+		];
+
+		// Set post excerpt if description is available.
+		if (isset($article->metadata['description'])) {
+			$data['post_excerpt'] = $article->metadata['description'];
+		}
+
+		// Set post title if override is available.
+		if (isset($article->metadata['title']) && $article->metadata['title']) {
+			$data['post_title'] = $article->metadata['title'];
+		}
+
+		return $data;
 	}
 }

--- a/app/Settings.php
+++ b/app/Settings.php
@@ -237,7 +237,7 @@ class Settings
 				$pccGrant = sanitize_text_field(filter_input(INPUT_GET, 'pccGrant'));
 
 				// Check if required parameters are present
-				if (!(empty($documentId) || empty($pccGrant))) {
+				if (empty($documentId) || empty($pccGrant)) {
 					wp_die(esc_html__('Content Publisher: Missing parameters for preview', 'pantheon-content-publisher-for-wordpress'));
 					exit;
 				}

--- a/app/Settings.php
+++ b/app/Settings.php
@@ -279,7 +279,8 @@ class Settings
 
 				if (empty($postId) || !is_numeric($postId) || $postId <= 0) {
 					wp_die(esc_html__(
-						'Content Publisher: Failed to preview this document. Confirm that this document is connected to your collection. ' .
+						'Content Publisher: Failed to preview this document. ' .
+						'Confirm that this document is connected to your collection. ' .
 						'Reach out to support if the issue persists.',
 						'pantheon-content-publisher-for-wordpress'
 					));
@@ -358,8 +359,7 @@ class Settings
 	 * @param WP_Query $query
 	 * @return array
 	 */
-	// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found - $query is required by the WordPress hook signature
-	public function temporaryPreview($posts, $query)
+	public function temporaryPreview($posts)
 	{
 		remove_filter('posts_results', [$this, 'temporaryPreview'], 10, 2);
 

--- a/app/Settings.php
+++ b/app/Settings.php
@@ -239,7 +239,10 @@ class Settings
 
 				// Check if required parameters are present
 				if (empty($documentId) || empty($pccGrant)) {
-					wp_die(esc_html__('Content Publisher: Missing parameters for preview', 'pantheon-content-publisher-for-wordpress'));
+					wp_die(esc_html__(
+						'Content Publisher: Missing parameters for preview',
+						'pantheon-content-publisher-for-wordpress'
+					));
 					exit;
 				}
 
@@ -248,7 +251,7 @@ class Settings
 
 				// Find the post associated with the document ID
 				$postId = $PCCManager->findExistingConnectedPost(
-					$documentId, 
+					$documentId,
 					'any' // Consider even draft posts
 				);
 
@@ -256,7 +259,7 @@ class Settings
 				if (!$postId) {
 					try {
 						// Fetch and store the document with the grant based client
-						// if the grant is invalid, the document will not be fetched 
+						// if the grant is invalid, the document will not be fetched
 						// and the post will not be created
 						$postId = $PCCManager->fetchAndStoreDocument(
 							$documentId,
@@ -265,13 +268,21 @@ class Settings
 							$pccClient
 						);
 					} catch (Exception $ex) {
-						wp_die(esc_html__('Content Publisher: Failed to preview this document. Your preview link may have expired. Try previewing this document again from Content Publisher.', 'pantheon-content-publisher-for-wordpress'));
+						wp_die(esc_html__(
+							'Content Publisher: Failed to preview this document. Your preview link may have expired. ' .
+							'Try previewing this document again from Content Publisher.',
+							'pantheon-content-publisher-for-wordpress'
+						));
 						$postId = 0;
 					}
 				}
 
 				if (empty($postId) || !is_numeric($postId) || $postId <= 0) {
-					wp_die(esc_html__('Content Publisher: Failed to preview this document. Confirm that this document is connected to your collection. Reach out to support if the issue persists.', 'pantheon-content-publisher-for-wordpress'));
+					wp_die(esc_html__(
+						'Content Publisher: Failed to preview this document. Confirm that this document is connected to your collection. ' .
+						'Reach out to support if the issue persists.',
+						'pantheon-content-publisher-for-wordpress'
+					));
 					exit;
 				}
 
@@ -325,7 +336,7 @@ class Settings
 	 */
 	public function handlePreviewPostResults($query)
 	{
-		if ( 
+		if (
 			$query->is_main_query() // Main page data query
 			&& $query->is_singular() // Single post/page
 			&& $this->isPreviewRequest() // Preview request
@@ -334,7 +345,7 @@ class Settings
 			// This is crucial so temporaryPreview receives the post object even if it's a draft.
 			$query->set('post_status', 'any');
 
-			add_filter( 'posts_results', [$this, 'temporaryPreview'], 10, 2 );
+			add_filter('posts_results', [$this, 'temporaryPreview'], 10, 2);
 		}
 	}
 
@@ -347,9 +358,10 @@ class Settings
 	 * @param WP_Query $query
 	 * @return array
 	 */
+	// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found - $query is required by the WordPress hook signature
 	public function temporaryPreview($posts, $query)
 	{
-		remove_filter( 'posts_results', [$this, 'temporaryPreview'], 10, 2 );
+		remove_filter('posts_results', [$this, 'temporaryPreview'], 10, 2);
 
 		if (empty($posts)) {
 			return $posts;
@@ -405,11 +417,10 @@ class Settings
 
 			// Disable comments/pings for preview display
 			add_filter('comments_open', '__return_false');
-			add_filter('pings_open',    '__return_false');
+			add_filter('pings_open', '__return_false');
 
 			// Return the array containing the modified post object
 			return $posts;
-
 		} catch (Exception $e) {
 			error_log('PCC Preview Error: Failed to fetch article ' . $documentId . ' - ' . $e->getMessage());
 			return $posts;

--- a/app/Settings.php
+++ b/app/Settings.php
@@ -316,6 +316,13 @@ class Settings
 		}
 	}
 
+	/**
+	 * Hook for pre_get_posts that allows us to extend the
+	 * results with custom logic.
+	 *
+	 * @param WP_Query $query
+	 * @return void
+	 */
 	public function handlePreviewPostResults($query)
 	{
 		if ( 
@@ -331,6 +338,15 @@ class Settings
 		}
 	}
 
+	/**
+	 * Filter for posts_results that allows us to temporarily
+	 * make a post object for a Content Publisher document
+	 * available for viewing regardless of its publishing status.
+	 *
+	 * @param array $posts
+	 * @param WP_Query $query
+	 * @return array
+	 */
 	public function temporaryPreview($posts, $query)
 	{
 		remove_filter( 'posts_results', [$this, 'temporaryPreview'], 10, 2 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pantheon-content-publisher-for-wordpress",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pantheon-content-publisher-for-wordpress",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "dependencies": {
         "@pantheon-systems/pcc-sdk-core": "3.11.3",
         "axios": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pantheon-content-publisher-for-wordpress",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Publish WordPress content from Google Docs with Pantheon Content Cloud.",
   "scripts": {
     "dev": "NODE_ENV=development node_modules/webpack/bin/webpack.js --progress --config=node_modules/laravel-mix/setup/webpack.config.js",


### PR DESCRIPTION
## Description
This PR adds the last set of changes for [PCC-2132](https://getpantheon.atlassian.net/browse/PCC-2132), specifically improving the preview experience.

The preview experience currently works by finding any published page, rendering the content for that page and then adding JS to replace and hydrate that content client side. 

This PR updates the plugin to render previews without depending on the existence of a published post. It also adds hooking into WP rendering logic so previews are rendered server-side first and then hydrated on the client.

## Checklist:

- [x] I've tested the code.
- [x] My code follows the repository code
  style. <!-- Ruleset: https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress/blob/primary/phpcs.xml/ -->
- [x] My code follows the accessibility
  standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the PHP DocBlock documentation
  standards. <!-- Resource: https://docs.phpdoc.org/guides/docblocks.html -->


[PCC-2132]: https://getpantheon.atlassian.net/browse/PCC-2132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ