### PR TITLE
Handle webhook publish event

### DIFF
--- a/.github/release.sh
+++ b/.github/release.sh
@@ -16,7 +16,6 @@ INCLUDES=(
 
 # Determine repository name from the current directory.
 REPO=$(basename "$(pwd)")
-DIR="$REPO"
 ZIP="${REPO}.zip"
 
 echo "Starting build process for $REPO..."
@@ -32,8 +31,6 @@ npm run prod
 
 echo "Creating release artifact: $ZIP..."
 
-# Create a temporary directory for the release files in the same directory
-
 echo "Creating temporary directory for release files at: $REPO"
 mkdir -p "$REPO"
 
@@ -47,7 +44,6 @@ for item in "${INCLUDES[@]}"; do
     fi
 done
 
-# Create the zip archive from the temporary directory
 echo "Creating zip archive..."
 
 # Remove existing zip file if it exists
@@ -58,7 +54,6 @@ fi
 
 zip -r "$ZIP" "$REPO"/*
 
-# Clean up the temporary directory
 echo "Cleaning up temporary directory..."
 rm -rf "$REPO"
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 .DS_Store
 *.code-workspace
 .idea
+pantheon-content-publisher-for-wordpress.zip

--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: getpantheon
 Tags: pantheon
 Requires at least: 5.7
 Tested up to: 6.6.2
-Stable tag: 1.2.3
+Stable tag: 1.2.4
 Requires PHP: 8.0.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -50,6 +50,9 @@ The connection will be established automatically.
 All posts/pages created with Pantheon Content Publisher will remain on your WordPress site. However, you will no longer be able to edit them from Google Docs.
 
 == Changelog ==
+= 1.2.4 =
+* Feature: Add support for article.publish webhook event
+
 = 1.2.3 =
 * Feature: Display collection ID on Connected Content Collection page.
 * Feature: Improve preview request handling.

--- a/README.txt
+++ b/README.txt
@@ -52,6 +52,7 @@ All posts/pages created with Pantheon Content Publisher will remain on your Word
 == Changelog ==
 = 1.2.4 =
 * Feature: Add support for article.publish webhook event
+* Fix: Adds support for linking between documents intra-site
 
 = 1.2.3 =
 * Feature: Display collection ID on Connected Content Collection page.

--- a/app/RestController.php
+++ b/app/RestController.php
@@ -135,6 +135,9 @@ class RestController
 			case 'article.unpublish':
 				$pccManager->unPublishPostByDocumentId($articleId);
 				break;
+			case 'article.publish':
+				$pccManager->fetchAndStoreDocument($articleId, PublishingLevel::PRODUCTION);
+				break;
 			default:
 				return new WP_REST_Response(
 					esc_html__('Event type is currently unsupported', 'pantheon-content-publisher-for-wordpress'),

--- a/app/Settings.php
+++ b/app/Settings.php
@@ -209,11 +209,11 @@ class Settings
 			return;
 		}
 
+		$publishingLevelParam = sanitize_text_field(filter_input(INPUT_GET, 'publishingLevel'));
+
 		// Default to production if no publishing level is provided
 		if (empty($publishingLevelParam)) {
 			$publishingLevelParam = PublishingLevel::PRODUCTION->value;
-		} else {
-			$publishingLevelParam = sanitize_text_field(filter_input(INPUT_GET, 'publishingLevel'));
 		}
 
 

--- a/app/Settings.php
+++ b/app/Settings.php
@@ -209,13 +209,19 @@ class Settings
 			return;
 		}
 
+		// Default to production if no publishing level is provided
+		if (empty($publishingLevelParam)) {
+			$publishingLevelParam = PublishingLevel::PRODUCTION->value;
+		} else {
+			$publishingLevelParam = sanitize_text_field(filter_input(INPUT_GET, 'publishingLevel'));
+		}
+
+
 		try {
 			$PCCManager = new PccSyncManager();
 
 			// Publish document
-			$publishingLevelParam = sanitize_text_field(filter_input(INPUT_GET, 'publishingLevel'));
 			if (
-				$publishingLevelParam &&
 				PublishingLevel::PRODUCTION->value === $publishingLevelParam &&
 				$PCCManager->isPCCConfigured()
 			) {
@@ -229,7 +235,6 @@ class Settings
 
 			// Preview document
 			if (
-				$publishingLevelParam &&
 				PublishingLevel::REALTIME->value === $publishingLevelParam &&
 				$PCCManager->isPCCConfigured()
 			) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pantheon-content-publisher-for-wordpress",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pantheon-content-publisher-for-wordpress",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "dependencies": {
         "@pantheon-systems/pcc-sdk-core": "3.11.3",
         "axios": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pantheon-content-publisher-for-wordpress",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Publish WordPress content from Google Docs with Pantheon Content Cloud.",
   "scripts": {
     "dev": "NODE_ENV=development node_modules/webpack/bin/webpack.js --progress --config=node_modules/laravel-mix/setup/webpack.config.js",

--- a/pantheon-content-publisher-for-wordpress.php
+++ b/pantheon-content-publisher-for-wordpress.php
@@ -8,7 +8,7 @@
  * Plugin URI: https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress/
  * Author: Pantheon
  * Author URI: https://pantheon.io
- * Version: 1.2.3
+ * Version: 1.2.4
  * License: GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
  */


### PR DESCRIPTION
## Description
- Adds support for handling publish events delivered by Content Publisher webhook
- Adds defaulting to PRODUCTION publish level in /api/pantheoncloud handler. This enables support for linking between articles in a site

<!-- Describe what you have changed or added. -->
<!-- Link to the issue(s) where appropriate. -->

## Testing instructions

<!-- Add instructions to help the reviewer test your code. -->
<!-- Include sample forms, add-ons or snippets where appropriate. -->

## Screenshots

<!-- if applicable -->

## Checklist:

- [x] I've tested the code.
- [x] My code follows the repository code
  style. <!-- Ruleset: https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress/blob/primary/phpcs.xml/ -->
- [x] My code follows the accessibility
  standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the PHP DocBlock documentation
  standards. <!-- Resource: https://docs.phpdoc.org/guides/docblocks.html -->
