### PR TITLE
add integration tab and support syncing metadata to Advanced Custom Fields

### DIFF
--- a/admin/templates/partials/connected-collection.php
+++ b/admin/templates/partials/connected-collection.php
@@ -3,75 +3,89 @@
 if (!\defined('ABSPATH')) {
 	exit;
 }
+//Get the active tab from the $_GET param
+$default_tab = null;
+$tab = isset($_GET['tab']) ? $_GET['tab'] : $default_tab;	
 ?>
 <div class="pcc-content">
-	<?php
-	require 'header.php';
-	?>
+	<?php require 'header.php'; ?>
 	<div class="page-content">
-		<div class="connected-collection-page">
-			<?php require PCC_PLUGIN_DIR . 'admin/templates/partials/error-message.php'; ?>
-			<div class="py-2.5">
-				<h3 class="text-grey font-bold text-sm mb-[0.5rem]">
-					<?php esc_html_e('Connected content collection', 'pantheon-content-publisher-for-wordpress') ?>
-				</h3>
-				<div class="page-grid mb-9">
-					<div class="col-span-8 justify-self-start break-all">
-						<h1 class="page-header">
-							<?php echo esc_url(site_url()) ?>
-						</h1>
-						<p class="font-bold text-sm mt-2">
-							<span class="text-grey font-normal">COLLECTION ID:</span>
-							<?php echo esc_html(get_option(PCC_SITE_ID_OPTION_KEY)) ?>
+		<nav class="nav-tab-wrapper">
+			<a href="?page=pantheon-content-publisher-for-wordpress" class="nav-tab <?php if($tab===null):?>nav-tab-active<?php endif; ?>">Connection</a>
+			<a href="?page=pantheon-content-publisher-for-wordpress&tab=integrations" class="nav-tab <?php if($tab==='integrations'):?>nav-tab-active<?php endif; ?>">Integration</a>
+		</nav>
+		<div class="tab-content">
+		<?php switch($tab) :
+		case 'integrations':
+			require 'integrations.php';
+			break;
+
+		default:
+		?>
+			<div class="connected-collection-page">
+				<?php require PCC_PLUGIN_DIR . 'admin/templates/partials/error-message.php'; ?>
+				<div class="py-2.5">
+					<h3 class="text-grey font-bold text-sm mb-[0.5rem]">
+						<?php esc_html_e('Connected content collection', 'pantheon-content-publisher-for-wordpress') ?>
+					</h3>
+					<div class="page-grid mb-9">
+						<div class="col-span-8 justify-self-start break-all">
+							<h1 class="page-header">
+								<?php echo esc_url(site_url()) ?>
+							</h1>
+							<p class="font-bold text-sm mt-2">
+								<span class="text-grey font-normal">COLLECTION ID:</span>
+								<?php echo esc_html(get_option(PCC_SITE_ID_OPTION_KEY)) ?>
+							</p>
+						</div>
+						<a class="secondary-button self-start col-span-4 justify-self-end" 
+							href="<?php echo esc_url(add_query_arg([
+							'page' => 'pantheon-content-publisher-for-wordpress',
+							'view' => 'disconnect-confirmation'
+						], admin_url('admin.php'))) ?>">
+							<span>
+								<?php esc_html_e('Disconnect collection', 'pantheon-content-publisher-for-wordpress') ?>
+							</span>
+						</a>
+					</div>
+					<div>
+						<div class="divider-border"></div>
+						<p class="text-lg font-bold mt-10 mb-[1.25rem]">
+							<?php esc_html_e('Publish your document as:', 'pantheon-content-publisher-for-wordpress') ?>
 						</p>
-					</div>
-					<a class="secondary-button self-start col-span-4 justify-self-end" 
-						href="<?php echo esc_url(add_query_arg([
-						'page' => 'pantheon-content-publisher-for-wordpress',
-						'view' => 'disconnect-confirmation'
-					], admin_url('admin.php'))) ?>">
-						<span>
-							<?php esc_html_e('Disconnect collection', 'pantheon-content-publisher-for-wordpress') ?>
-						</span>
-					</a>
-				</div>
-				<div>
-					<div class="divider-border"></div>
-					<p class="text-lg font-bold mt-10 mb-[1.25rem]">
-						<?php esc_html_e('Publish your document as:', 'pantheon-content-publisher-for-wordpress') ?>
-					</p>
-					<div class="inputs-container">
-						<div class='input-wrapper'>
-							<input class='radio-input' name='post_type' type='radio' value='post' id='radio-post' <?php
-							checked(get_option(PCC_INTEGRATION_POST_TYPE_OPTION_KEY), 'post');
-							?>>
-							<label class="text-base" for="radio-post">
-								<?php
-								$labels = get_post_type_labels(get_post_type_object('post'));
-								echo esc_html($labels->singular_name);
-								?>
-							</label>
+						<div class="inputs-container">
+							<div class='input-wrapper'>
+								<input class='radio-input' name='post_type' type='radio' value='post' id='radio-post' <?php
+								checked(get_option(PCC_INTEGRATION_POST_TYPE_OPTION_KEY), 'post');
+								?>>
+								<label class="text-base" for="radio-post">
+									<?php
+									$labels = get_post_type_labels(get_post_type_object('post'));
+									echo esc_html($labels->singular_name);
+									?>
+								</label>
+							</div>
+							<div class='input-wrapper'>
+								<input class='radio-input' name='post_type' type='radio' value='page' id='radio-page' <?php
+								checked(get_option(PCC_INTEGRATION_POST_TYPE_OPTION_KEY), 'page');
+								?>>
+								<label class="text-base" for="radio-page">
+									<?php
+									$labels = get_post_type_labels(get_post_type_object('page'));
+									echo esc_html($labels->singular_name);
+									?>
+								</label>
+							</div>
 						</div>
-						<div class='input-wrapper'>
-							<input class='radio-input' name='post_type' type='radio' value='page' id='radio-page' <?php
-							checked(get_option(PCC_INTEGRATION_POST_TYPE_OPTION_KEY), 'page');
-							?>>
-							<label class="text-base" for="radio-page">
-								<?php
-								$labels = get_post_type_labels(get_post_type_object('page'));
-								echo esc_html($labels->singular_name);
-								?>
-							</label>
-						</div>
+						<a class="primary-button" id="pcc-update-collection" href="#">
+							<?php esc_html_e('Save configuration', 'pantheon-content-publisher-for-wordpress') ?>
+						</a>
 					</div>
-					<a class="primary-button" id="pcc-update-collection" href="#">
-						<?php esc_html_e('Save configuration', 'pantheon-content-publisher-for-wordpress') ?>
-					</a>
 				</div>
 			</div>
-			<?php
-			require 'footer.php';
-			?>
-		</div>
-	</div>
+
+		<?php break; endswitch; ?>
+		<?php require 'footer.php'; ?>
+		</div><!-- end tab-content -->
+	</div><!-- end page-content -->
 </div>

--- a/admin/templates/partials/integrations.php
+++ b/admin/templates/partials/integrations.php
@@ -1,0 +1,74 @@
+<?php
+// Exit if accessed directly.
+if (!\defined('ABSPATH')) {
+	exit;
+}
+$activePlugins = apply_filters('active_plugins', get_option('active_plugins'));
+?>
+<div class="connected-collection-page integrations text-lg">
+	<div class="py-2.5">
+		<h3 class="font-bold mb-[0.5rem]">Advanced Custom Fields</h3>
+		<p class="text-lg text-grey">Metadata fields defined in the Pantheon Content Publisher collection can be synced to Advanced Custom Fields.</p>
+
+		<?php if (in_array('advanced-custom-fields/acf.php', $activePlugins)) : ?>
+		<?php
+			// Kludgy way to get all ACF fields, we need a post so use the first one.
+			$wp_query = new WP_Query(array('post_type' => 'post'));
+			if ( $wp_query->have_posts() ) : ?>
+			<?php
+				$field_groups = acf_get_field_groups(array('post_id' => $wp_query->posts[0]->ID));
+				foreach ( $field_groups as $group ) : ?>
+					<table class="widefat fixed mt-10" cellspacing="0">
+						<thead>
+							<tr>
+								<th width="30%" scope="col">Advanced Custom Fields</th>
+								<th width="10%" scope="col">Type</th>
+								<th width="60%" scope="col">Content Publisher</th>
+							</tr>
+						</thead>
+						<tfoot>
+							<th colspan="3">ACF field group: <?php echo $group['title']; ?></th>
+						</tfoot>
+						<tbody>
+						<?php 
+							$fields = acf_get_fields($group['ID']);
+							$metadata_map = get_option(PCC_INTEGRATION_METADATA_MAP, []);
+							$metadata_user_map = get_option(PCC_INTEGRATION_METADATA_USER_MAP, 'login');
+							$i = 0;
+							foreach ($fields as $field) : ?>
+								<tr class="<?php if ($i++ % 2) echo 'alternate'; ?>">
+									<td class="text-lg"><label for="acf--<?php echo $field['name']; ?>"><?php echo $field['label']; ?></label></td>
+									<td class="text-lg"><?php echo  $field['type']; ?></td>
+									<td class="text-lg">
+										<input  type="text"
+												value="<?php if (!is_null($metadata_map) && array_key_exists($field['name'], $metadata_map)) echo $metadata_map[$field['name']]; ?>"
+												placeholder="Content Publisher field name"										
+												data-integration="acf"
+												id="acf--<?php echo $field['name']; ?>"
+												name="<?php echo $field['name']; ?>" 
+												class="input-with-border" />
+									</td>
+								</tr>
+							<?php endforeach; ?>
+						</tbody>
+					</table>
+				<?php endforeach; 
+			endif; //end have posts
+		?>
+		<div class="inputs-container mt-10">
+			<p class="text-lg">Map ACF user fields by matching:</p>
+			<div class="input-wrapper">
+				<input class="radio-input" type="radio" id="map-user-login" name="acf-user-map" value="login"<?php if ($metadata_user_map == 'login') echo ' checked="checked"'; ?>>
+				<label class="text-base" for="map-user-login">User login</label><br>
+			</div>
+			<div class="input-wrapper">
+				<input class="radio-input" type="radio" id="map-user-email" name="acf-user-map" value="email"<?php if ($metadata_user_map == 'email') echo ' checked="checked"'; ?>>
+				<label class="text-base" for="map-user-email">User email</label><br>		
+			</div>
+		</div>
+		<button id="pcc-app-integration-acf" class="primary-button">
+			<?php esc_html_e('Update Metadata Mapping', 'pantheon-content-publisher-for-wordpress') ?>
+		</button>
+		<?php endif; //end acf active ?>
+	</div>
+</div>

--- a/app/PccSyncManager.php
+++ b/app/PccSyncManager.php
@@ -175,6 +175,23 @@ class PccSyncManager
 				update_post_meta($postId, '_yoast_wpseo_metadesc', $article->metadata['description']);
 			}
 		}
+
+		if (in_array('advanced-custom-fields/acf.php', $activePlugins)) {
+			foreach (get_option(PCC_INTEGRATION_METADATA_MAP, []) as $key => $value) {
+				if (!empty($value) && isset($article->metadata[$value]))
+				{
+					$acfField = get_field_object($key, $postId);
+					if ($acfField['type'] == 'user')
+					{
+						$user_obj = get_user_by(get_option(PCC_INTEGRATION_METADATA_USER_MAP, 'login'), $article->metadata[$value]);
+						if ($user_obj != null)
+							update_post_meta($postId, $key, $user_obj->ID);
+					}
+					else
+						update_post_meta($postId, $key, $article->metadata[$value]);
+				}
+			}
+		}
 	}
 
 	/**

--- a/app/RestController.php
+++ b/app/RestController.php
@@ -80,6 +80,11 @@ class RestController
 				'method' => 'GET',
 				'callback' => [$this, 'pantheonCloudStatusCheck'],
 			],
+			[
+				'route' => '/integrations/metadata',
+				'method' => 'PUT',
+				'callback' => [$this, 'updateMetadataMapping'],
+			],
 		];
 
 		foreach ($endpoints as $endpoint) {
@@ -332,6 +337,23 @@ class RestController
 
 		return new WP_REST_Response(
 			esc_html__('Saved Data deleted.', 'pantheon-content-publisher-for-wordpress'),
+			200
+		);
+	}
+
+	/**
+	 * Update metadata settings
+	 *
+	 * @param WP_REST_Request $request
+	 * @return WP_REST_Response
+	 */
+	public function updateMetadataMapping(WP_REST_Request $request): WP_REST_Response
+	{
+		update_option(PCC_INTEGRATION_METADATA_MAP, json_decode(sanitize_text_field($request->get_param('metadataMap')), true) ?: []);
+		update_option(PCC_INTEGRATION_METADATA_USER_MAP, sanitize_text_field($request->get_param('userMap')));
+
+		return new WP_REST_Response(
+			esc_html__('Metadata mapping saved.', 'pantheon-content-publisher-for-wordpress'),
 			200
 		);
 	}

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -274,3 +274,13 @@
 
     @apply ms-[1rem];
 }
+
+/** Settings tabs **/
+.pcc-content .nav-tab-wrapper {
+    max-width: 1280px;
+    margin: auto;    
+    padding-left: 24px;
+}
+.pcc-content .nav-tab-wrapper .nav-tab-active {
+    background-color: #FFF;
+}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -3,6 +3,7 @@ import createSite from "./createSite";
 import {hideErrorMessage, hideSpinner, showErrorMessage, showSpinner, updateSpinnerText} from "./helper";
 import updatePostType from "./updatePostType";
 import authenticate from "./authenticate";
+import updateMetadataMapping from "./integrations";
 
 if (document.getElementById('pcc-app-authenticate') != undefined) {
 	document.getElementById('pcc-app-authenticate').addEventListener('click', async function () {
@@ -52,5 +53,17 @@ if (document.getElementById('pcc-disconnect') != undefined) {
 if (document.getElementById('pcc-error-close-button') != undefined) {
 	document.getElementById('pcc-error-close-button').addEventListener('click', function () {
 		hideErrorMessage();
+	});
+}
+
+if (document.getElementById('pcc-app-integration-acf') != undefined) {
+	document.getElementById('pcc-app-integration-acf').addEventListener('click', async function () {
+		try {
+			showSpinner();
+			await updateMetadataMapping();
+		} catch (error) {
+			showErrorMessage(`Error while saving acf mapping: ${error.message}`)
+			hideSpinner();
+		}
 	});
 }

--- a/assets/js/integrations.js
+++ b/assets/js/integrations.js
@@ -1,0 +1,40 @@
+import {showSpinner, updateSpinnerText} from "./helper"; //getSelectedPostType, 
+import axios from "axios";
+
+export default function updateMetadataMapping() {
+	return new Promise(
+		async (resolve, reject) => {
+			try {
+				showSpinner();
+				updateSpinnerText('Updating metadata mapping...');
+				var map = {};
+				const allInputs = document.querySelectorAll("input[data-integration='acf']");
+				allInputs.forEach((input) => {
+					map[input.name ] = input.value;
+				});
+
+				const userMap = document.querySelector('input[name="acf-user-map"]:checked')?.value;
+				await saveMetadataMapping(map, userMap);
+				resolve();
+			} catch (error) {
+				updateSpinnerText('Error while updating metadata mapping. Please try again.');
+				reject(error);
+			}
+		},);
+}
+
+/**
+ * Update integration post type in database
+ *
+ * @param postType
+ * @returns {Promise<axios.AxiosResponse<any>>}
+ */
+async function saveMetadataMapping(map, userMap) {
+	const { rest_url, nonce } = window.PCCAdmin;
+	return await axios.put(`${rest_url}/integrations/metadata`, {
+		metadataMap: JSON.stringify(map),
+		userMap: userMap,
+	}, {
+		headers: { 'X-WP-Nonce': nonce }
+	});
+}

--- a/pantheon-content-publisher-for-wordpress.php
+++ b/pantheon-content-publisher-for-wordpress.php
@@ -33,6 +33,8 @@ define('PCC_API_NAMESPACE', 'pcc/v1');
 define('PCC_CONTENT_META_KEY', 'pcc_id');
 define('PCC_ENDPOINT', 'https://addonapi-gfttxsojwq-uc.a.run.app');
 define('PCC_WEBHOOK_SECRET_OPTION_KEY', 'pcc_webhook_secret');
+define('PCC_INTEGRATION_METADATA_MAP', 'pcc_integration_metadata_map');
+define('PCC_INTEGRATION_METADATA_USER_MAP', 'pcc_integration_metadata_user_map');
 
 call_user_func(static function ($rootPath) {
 	$autoload = "{$rootPath}vendor/autoload.php";


### PR DESCRIPTION
## Description

- modifies connected-collection.php to add Connection and Integration tabs (and structure for future tabs)
- adds new integrations.php tab page that displays ACF metadata mapping settings
- applies metadata mapping settings on PccSyncManager

## Testing instructions

- add text metadata field named Assigned Editor in CP collection
- install and enable ACF plugin
- create ACF text field named Assigned Editor in WP
- go to Content Publisher plugin integrations tab and add the name of the metadata field ("Assigned Editor") to map to the ACF field ("Assigned Editor"), save
- publish a document to WP with any value as Assigned Editor 
- view the post in WP and edit, you should see the same value in the Assigned Editor ACF field

## Screenshots


## Checklist:

- [x] I've tested the code.
- [x] My code follows the repository code
  style. <!-- Ruleset: https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress/blob/primary/phpcs.xml/ -->
- [x] My code follows the accessibility
  standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the PHP DocBlock documentation
  standards. <!-- Resource: https://docs.phpdoc.org/guides/docblocks.html -->
