### PR TITLE
[SITE-4824] Update SDK tag for Wordpress Validation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   },
   "require": {
     "php": ">=8",
-    "pantheon-systems/pcc-php-sdk": "dev-main"
+    "pantheon-systems/pcc-php-sdk": "1.0.0"
   },
   "require-dev": {
     "wp-coding-standards/wpcs": "^3.1",


### PR DESCRIPTION
This patch updates the tag of our PCC-PHP-SDK to a stable tag: 1.0.0 to conform to WordPress validation standards when resubmitting this plugin. 