### PR TITLE
[PCC 2255] Add support for draft publishing level and versions

### DIFF
--- a/app/PccSyncManager.php
+++ b/app/PccSyncManager.php
@@ -32,13 +32,16 @@ class PccSyncManager
 	 * @param $documentId
 	 * @param PublishingLevel $publishingLevel
 	 * @param bool $isDraft
+	 * @param PccClient|null $pccClient
+	 * @param string|null $versionId
 	 * @return int
 	 */
 	public function fetchAndStoreDocument(
 		$documentId,
 		PublishingLevel $publishingLevel,
 		bool $isDraft = false,
-		PccClient $pccClient = null
+		PccClient $pccClient = null,
+		?string $versionId = null 
 	): int {
 		$articlesApi = new ArticlesApi($pccClient ?? $this->pccClient());
 		$article = $articlesApi->getArticleById(
@@ -52,7 +55,8 @@ class PccSyncManager
 				'metadata',
 			],
 			$publishingLevel,
-			ContentType::TREE_PANTHEON_V2
+			ContentType::TREE_PANTHEON_V2,
+			$versionId
 		);
 
 		return $article ? $this->storeArticle($article, $isDraft) : 0;
@@ -341,19 +345,24 @@ class PccSyncManager
 	 * @param string $documentId
 	 * @param $postId
 	 * @param $pccGrant
+	 * @param string|null $versionId
+	 * @param PublishingLevel|null $publishingLevel
 	 * @return string
 	 */
-	public function preparePreviewingURL(string $documentId, $postId = null, $pccGrant = null): string
+	public function preparePreviewingURL(string $documentId, $postId = null, $pccGrant = null, ?PublishingLevel $publishingLevel = null, ?string $versionId = null): string
 	{
 		$postId = $postId ?: $this->findExistingConnectedPost($documentId);
-		return add_query_arg(
-			[
-				'publishing_level' => PublishingLevel::REALTIME->value,
-				'document_id' => $documentId,
-				'pccGrant' => $pccGrant,
-			],
-			get_permalink($postId)
-		);
+		$queryArgs = [
+			'publishing_level' => ($publishingLevel ?? PublishingLevel::REALTIME)->value,
+			'document_id' => $documentId,
+			'pccGrant' => $pccGrant,
+		];
+		
+		if ($versionId) {
+			$queryArgs['versionId'] = $versionId;
+		}
+		
+		return add_query_arg($queryArgs, get_permalink($postId));
 	}
 
 	/**

--- a/app/Settings.php
+++ b/app/Settings.php
@@ -237,12 +237,13 @@ class Settings
 
 			// Preview document
 			if (
-				PublishingLevel::REALTIME->value === $publishingLevelParam &&
+				(PublishingLevel::REALTIME->value === $publishingLevelParam || PublishingLevel::DRAFT->value === $publishingLevelParam) &&
 				$PCCManager->isPCCConfigured()
 			) {
 				$parts = explode('/', $wp->request);
 				$documentId = sanitize_text_field(wp_unslash(end($parts)));
 				$pccGrant = sanitize_text_field(filter_input(INPUT_GET, 'pccGrant'));
+				$versionId = sanitize_text_field(filter_input(INPUT_GET, 'versionId'));
 
 				// Check if required parameters are present
 				if (empty($documentId) || empty($pccGrant)) {
@@ -268,11 +269,13 @@ class Settings
 						// Fetch and store the document with the grant based client
 						// if the grant is invalid, the document will not be fetched
 						// and the post will not be created
+						$publishingLevel = $publishingLevelParam === PublishingLevel::DRAFT->value ? PublishingLevel::DRAFT : PublishingLevel::REALTIME;
 						$postId = $PCCManager->fetchAndStoreDocument(
 							$documentId,
-							PublishingLevel::REALTIME,
+							$publishingLevel,
 							true,
-							$pccClient
+							$pccClient,
+							$versionId ?: null
 						);
 					} catch (Exception $ex) {
 						wp_die(esc_html__(
@@ -296,7 +299,7 @@ class Settings
 
 
 				// Generate the preview URL using the specific post ID found or created
-				$url = $PCCManager->preparePreviewingURL($documentId, $postId, $pccGrant);
+				$url = $PCCManager->preparePreviewingURL($documentId, $postId, $pccGrant, $publishingLevel, $versionId ?: null);
 
 				wp_redirect($url);
 				exit;
@@ -377,6 +380,8 @@ class Settings
 		$post = $posts[0];
 		$pccGrant = sanitize_text_field(filter_input(INPUT_GET, 'pccGrant'));
 		$documentId = sanitize_text_field(filter_input(INPUT_GET, 'document_id'));
+		$versionId = sanitize_text_field(filter_input(INPUT_GET, 'versionId'));
+		$publishingLevelParam = sanitize_text_field(filter_input(INPUT_GET, 'publishing_level'));
 
 		if (empty($pccGrant) || empty($documentId)) {
 			// Return original posts if params are missing. WP might show draft/404.
@@ -387,7 +392,7 @@ class Settings
 			// Initialize PCC client with the grant
 			$pccClient = (new PccSyncManager())->pccClient($pccGrant);
 			$articlesApi = new ArticlesApi($pccClient);
-			$publishingLevel = PublishingLevel::REALTIME;
+			$publishingLevel = $publishingLevelParam === PublishingLevel::DRAFT->value ? PublishingLevel::DRAFT : PublishingLevel::REALTIME;
 
 			// Fetch the article data needed for prerendering the
 			// preview page. This also serves as a guard to ensure
@@ -401,7 +406,8 @@ class Settings
 					'metadata',
 				],
 				$publishingLevel,
-				ContentType::TREE_PANTHEON_V2
+				ContentType::TREE_PANTHEON_V2,
+				$versionId ?: null
 			);
 
 			// If fetching the article fails (invalid grant, network error, document deleted),

--- a/assets/js/pcc-front.js
+++ b/assets/js/pcc-front.js
@@ -5,19 +5,27 @@ const params = new URLSearchParams(url.search);
 const siteId = params.get('site_id') || window.PCCFront.site_id;
 const documentId = params.get('document_id');
 const pccGrant = params.get('pccGrant');
+const versionId = params.get('versionId');
+const publishingLevel = params.get('publishing_level') || PublishingLevel.REALTIME;
 
 const pantheonClient = new PantheonClient({
     siteId: siteId,
     pccGrant: pccGrant,
 });
 
+const subscriptionVariables = {
+    id: documentId,
+    contentType: "TREE_PANTHEON_V2",
+    publishingLevel,
+};
+
+if (versionId) {
+    subscriptionVariables.versionId = versionId;
+}
+
 const observable = pantheonClient.apolloClient.subscribe({
     query: ARTICLE_UPDATE_SUBSCRIPTION,
-    variables: {
-        id: documentId,
-        contentType: "TREE_PANTHEON_V2",
-        publishingLevel: PublishingLevel.REALTIME,
-    },
+    variables: subscriptionVariables,
 });
 
 observable.subscribe({


### PR DESCRIPTION
## Description
Adds support to the SDK for fetching DRAFT publishing levels and version ids, with the goal of supporting the approval workflow in Wordpress and Drupal

## Checklist:

- [x] I've tested the code.
- [x] My code follows the repository code
  style. <!-- Ruleset: https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress/blob/primary/phpcs.xml/ -->
- [x] My code follows the accessibility
  standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the PHP DocBlock documentation
  standards. <!-- Resource: https://docs.phpdoc.org/guides/docblocks.html -->
