### PR TITLE
[SITE-4830]Updates prefix pcc to content_pub

### DIFF
--- a/admin/templates/partials/connected-collection.php
+++ b/admin/templates/partials/connected-collection.php
@@ -10,7 +10,7 @@ if (!\defined('ABSPATH')) {
 	?>
 	<div class="page-content">
 		<div class="connected-collection-page">
-			<?php require PCC_PLUGIN_DIR . 'admin/templates/partials/error-message.php'; ?>
+			<?php require CONTENT_PUB_PLUGIN_DIR . 'admin/templates/partials/error-message.php'; ?>
 			<div class="py-2.5">
 				<h3 class="text-grey font-bold text-sm mb-[0.5rem]">
 					<?php esc_html_e('Connected content collection', 'pantheon-content-publisher-for-wordpress') ?>
@@ -22,7 +22,7 @@ if (!\defined('ABSPATH')) {
 						</h1>
 						<p class="font-bold text-sm mt-2">
 							<span class="text-grey font-normal">COLLECTION ID:</span>
-							<?php echo esc_html(get_option(PCC_SITE_ID_OPTION_KEY)) ?>
+							<?php echo esc_html(get_option(CONTENT_PUB_SITE_ID_OPTION_KEY)) ?>
 						</p>
 					</div>
 					<a class="secondary-button self-start col-span-4 justify-self-end" 
@@ -43,7 +43,7 @@ if (!\defined('ABSPATH')) {
 					<div class="inputs-container">
 						<div class='input-wrapper'>
 							<input class='radio-input' name='post_type' type='radio' value='post' id='radio-post' <?php
-							checked(get_option(PCC_INTEGRATION_POST_TYPE_OPTION_KEY), 'post');
+							checked(get_option(CONTENT_PUB_INTEGRATION_POST_TYPE_OPTION_KEY), 'post');
 							?>>
 							<label class="text-base" for="radio-post">
 								<?php
@@ -54,7 +54,7 @@ if (!\defined('ABSPATH')) {
 						</div>
 						<div class='input-wrapper'>
 							<input class='radio-input' name='post_type' type='radio' value='page' id='radio-page' <?php
-							checked(get_option(PCC_INTEGRATION_POST_TYPE_OPTION_KEY), 'page');
+							checked(get_option(CONTENT_PUB_INTEGRATION_POST_TYPE_OPTION_KEY), 'page');
 							?>>
 							<label class="text-base" for="radio-page">
 								<?php

--- a/admin/templates/partials/create-collection.php
+++ b/admin/templates/partials/create-collection.php
@@ -70,8 +70,9 @@ if (!\defined('ABSPATH')) {
 						</div>
 					</div>
 					<div class="col-span-5 justify-self-end">
-						<img src="<?php echo esc_url(CONTENT_PUB_PLUGIN_DIR_URL . 'assets/images/collection-image.png') ?>"
-							 alt="collection-image"
+						<img src="<?php
+								echo esc_url(CONTENT_PUB_PLUGIN_DIR_URL . 'assets/images/collection-image.png') ?>"
+							alt="collection-image"
 						>
 					</div>
 				</div>

--- a/admin/templates/partials/create-collection.php
+++ b/admin/templates/partials/create-collection.php
@@ -9,10 +9,10 @@ if (!\defined('ABSPATH')) {
 	require 'header.php';
 	?>
 	<div class="page-content">
-		<?php require PCC_PLUGIN_DIR . 'admin/templates/partials/spinner.php'; ?>
+		<?php require CONTENT_PUB_PLUGIN_DIR . 'admin/templates/partials/spinner.php'; ?>
 		<div id="pcc-content">
 			<div class="create-collection-page">
-				<?php require PCC_PLUGIN_DIR . 'admin/templates/partials/error-message.php'; ?>
+				<?php require CONTENT_PUB_PLUGIN_DIR . 'admin/templates/partials/error-message.php'; ?>
 				<div class="page-grid">
 					<div class="col-span-7 justify-self-start">
 						<h1 class="page-header mt-[1.875rem]">
@@ -34,7 +34,7 @@ if (!\defined('ABSPATH')) {
 									   value="post"
 									   id="radio-post"
 									<?php
-									checked(get_option(PCC_INTEGRATION_POST_TYPE_OPTION_KEY), 'post');
+									checked(get_option(CONTENT_PUB_INTEGRATION_POST_TYPE_OPTION_KEY), 'post');
 									?>
 								>
 								<label class="text-base" for="radio-post">
@@ -49,7 +49,7 @@ if (!\defined('ABSPATH')) {
 									   value='page'
 									   id='radio-page'
 									<?php
-									checked(get_option(PCC_INTEGRATION_POST_TYPE_OPTION_KEY), 'page');
+									checked(get_option(CONTENT_PUB_INTEGRATION_POST_TYPE_OPTION_KEY), 'page');
 									?>
 								>
 								<label class="text-base" for="radio-page">
@@ -70,7 +70,7 @@ if (!\defined('ABSPATH')) {
 						</div>
 					</div>
 					<div class="col-span-5 justify-self-end">
-						<img src="<?php echo esc_url(PCC_PLUGIN_DIR_URL . 'assets/images/collection-image.png') ?>"
+						<img src="<?php echo esc_url(CONTENT_PUB_PLUGIN_DIR_URL . 'assets/images/collection-image.png') ?>"
 							 alt="collection-image"
 						>
 					</div>

--- a/admin/templates/partials/disconnect-confirmation.php
+++ b/admin/templates/partials/disconnect-confirmation.php
@@ -9,10 +9,10 @@ if (!\defined('ABSPATH')) {
 	require 'header.php';
 	?>
 	<div class="page-content">
-		<?php require PCC_PLUGIN_DIR . 'admin/templates/partials/spinner.php'; ?>
+		<?php require CONTENT_PUB_PLUGIN_DIR . 'admin/templates/partials/spinner.php'; ?>
 		<div id="pcc-content">
 			<div class="disconnect-confirm-page">
-				<?php require PCC_PLUGIN_DIR . 'admin/templates/partials/error-message.php'; ?>
+				<?php require CONTENT_PUB_PLUGIN_DIR . 'admin/templates/partials/error-message.php'; ?>
 				<div class="page-grid">
 					<div class="col-span-7">
 						<h1 class="page-header">
@@ -49,7 +49,7 @@ if (!\defined('ABSPATH')) {
 						</div>
 					</div>
 					<div class="col-span-5 justify-self-end">
-						<img src="<?php echo esc_url(PCC_PLUGIN_DIR_URL . 'assets/images/Inspection.png') ?>"
+						<img src="<?php echo esc_url(CONTENT_PUB_PLUGIN_DIR_URL . 'assets/images/Inspection.png') ?>"
 							 alt="Inspection images"
 						>
 					</div>

--- a/admin/templates/partials/error-message.php
+++ b/admin/templates/partials/error-message.php
@@ -6,13 +6,13 @@ if (!\defined('ABSPATH')) {
 ?>
 <div id="pcc-error-message" class="pcc-error-message hidden flex justify-between">
 	<div class="flex items-center gap-2.5">
-		<img src="<?php echo esc_url(PCC_PLUGIN_DIR_URL . 'assets/images/diamond-exclamation.png') ?>"
+		<img src="<?php echo esc_url(CONTENT_PUB_PLUGIN_DIR_URL . 'assets/images/diamond-exclamation.png') ?>"
 			 alt="Diamond exclamation icon">
 		<div id="pcc-error-text"></div>
 	</div>
 	<div class="flex items-center gap-4">
 		<button id="pcc-error-close-button">
-			<img src="<?php echo esc_url(PCC_PLUGIN_DIR_URL . 'assets/images/close-icon.png') ?>"
+			<img src="<?php echo esc_url(CONTENT_PUB_PLUGIN_DIR_URL . 'assets/images/close-icon.png') ?>"
 				 alt="Close icon">
 		</button>
 	</div>

--- a/admin/templates/partials/header.php
+++ b/admin/templates/partials/header.php
@@ -6,7 +6,7 @@ if (!\defined('ABSPATH')) {
 ?>
 <div class="header">
 	<img src="<?php
-	echo esc_url(PCC_PLUGIN_DIR_URL . 'assets/images/pantheon-logo.svg') ?>" alt="Pantheon Logo">
+	echo esc_url(CONTENT_PUB_PLUGIN_DIR_URL . 'assets/images/pantheon-logo.svg') ?>" alt="Pantheon Logo">
 	<span class="header-title"><?php
 		esc_html_e('Content Publisher', 'pantheon-content-publisher-for-wordpress') ?></span>
 </div>

--- a/admin/templates/partials/plugin-notification.php
+++ b/admin/templates/partials/plugin-notification.php
@@ -9,7 +9,7 @@ if (!\defined('ABSPATH')) {
 		<div class="continue-setup">
 			<div class="header">
 				<img src="<?php
-				echo esc_url(PCC_PLUGIN_DIR_URL . 'assets/images/pantheon-logo.svg') ?>"
+				echo esc_url(CONTENT_PUB_PLUGIN_DIR_URL . 'assets/images/pantheon-logo.svg') ?>"
 					 alt="Pantheon Logo">
 				<span class="header-title">
 					<?php

--- a/admin/templates/partials/setup.php
+++ b/admin/templates/partials/setup.php
@@ -9,10 +9,10 @@ if (!\defined('ABSPATH')) {
 	require 'header.php';
 	?>
 	<div class="page-content">
-		<?php require PCC_PLUGIN_DIR . 'admin/templates/partials/spinner.php'; ?>
+		<?php require CONTENT_PUB_PLUGIN_DIR . 'admin/templates/partials/spinner.php'; ?>
 		<div id="pcc-content">
 			<div class="welcome-page">
-				<?php require PCC_PLUGIN_DIR . 'admin/templates/partials/error-message.php'; ?>
+				<?php require CONTENT_PUB_PLUGIN_DIR . 'admin/templates/partials/error-message.php'; ?>
 				<div class="page-grid mt-6">
 					<div class="col-span-8">
 						<div class="w-[80%]">
@@ -32,12 +32,12 @@ if (!\defined('ABSPATH')) {
 								<?php esc_html_e('Management token', 'pantheon-content-publisher-for-wordpress') ?>
 							</span>
 								<img class="scale-110 ms-1 pb-2.5 inline"
-									 src="<?php echo esc_url(PCC_PLUGIN_DIR_URL . 'assets/images/red-dot.svg') ?>"
+									 src="<?php echo esc_url(CONTENT_PUB_PLUGIN_DIR_URL . 'assets/images/red-dot.svg') ?>"
 									 alt="Red Dot Icon">
 								<div class="tooltip inline">
 									<img class="scale-110 ms-2 pb-1 inline"
 										 src="<?php echo
-											esc_url(PCC_PLUGIN_DIR_URL . 'assets/images/circle-info.svg') ?>"
+											esc_url(CONTENT_PUB_PLUGIN_DIR_URL . 'assets/images/circle-info.svg') ?>"
 										 alt="Circle Info">
 									<span class="tooltip-text">
 									<?php
@@ -74,7 +74,7 @@ if (!\defined('ABSPATH')) {
 						</p>
 					</div>
 					<div class="col-span-4 self-start justify-self-end">
-						<img src="<?php echo esc_url(PCC_PLUGIN_DIR_URL . 'assets/images/multi-icons.png') ?>"
+						<img src="<?php echo esc_url(CONTENT_PUB_PLUGIN_DIR_URL . 'assets/images/multi-icons.png') ?>"
 							 alt="Pantheon Logo">
 					</div>
 				</div>

--- a/admin/templates/partials/setup.php
+++ b/admin/templates/partials/setup.php
@@ -32,7 +32,8 @@ if (!\defined('ABSPATH')) {
 								<?php esc_html_e('Management token', 'pantheon-content-publisher-for-wordpress') ?>
 							</span>
 								<img class="scale-110 ms-1 pb-2.5 inline"
-									 src="<?php echo esc_url(CONTENT_PUB_PLUGIN_DIR_URL . 'assets/images/red-dot.svg') ?>"
+									 src="<?php
+									 echo esc_url(CONTENT_PUB_PLUGIN_DIR_URL . 'assets/images/red-dot.svg') ?>"
 									 alt="Red Dot Icon">
 								<div class="tooltip inline">
 									<img class="scale-110 ms-2 pb-1 inline"

--- a/admin/templates/partials/setup.php
+++ b/admin/templates/partials/setup.php
@@ -33,7 +33,7 @@ if (!\defined('ABSPATH')) {
 							</span>
 								<img class="scale-110 ms-1 pb-2.5 inline"
 									 src="<?php
-									 echo esc_url(CONTENT_PUB_PLUGIN_DIR_URL . 'assets/images/red-dot.svg') ?>"
+										echo esc_url(CONTENT_PUB_PLUGIN_DIR_URL . 'assets/images/red-dot.svg') ?>"
 									 alt="Red Dot Icon">
 								<div class="tooltip inline">
 									<img class="scale-110 ms-2 pb-1 inline"

--- a/admin/templates/partials/spinner.php
+++ b/admin/templates/partials/spinner.php
@@ -6,7 +6,7 @@ if (!\defined('ABSPATH')) {
 ?>
 <div id="spinner-box" class="hidden">
 	<div class="pcc-spinner-container">
-		<img class="pcc-spinner" src="<?php echo esc_url(PCC_PLUGIN_DIR_URL . 'assets/images/spinner.svg') ?>"
+		<img class="pcc-spinner" src="<?php echo esc_url(CONTENT_PUB_PLUGIN_DIR_URL . 'assets/images/spinner.svg') ?>"
 			 alt="Spinner icon">
 		<p id="spinner-text" class="text-base"></p>
 	</div>

--- a/app/PccPostsListTable.php
+++ b/app/PccPostsListTable.php
@@ -48,25 +48,25 @@ class PccPostsListTable extends \WP_Posts_List_Table
 
 
 	/**
-	 * Checks if the post has the 'pcc_id' meta-key.
+	 * Checks if the post has the 'content_pub_id' meta-key.
 	 *
 	 * This method determines if the custom condition is met based on the existence
 	 * of a specific post-meta key.
 	 *
 	 * @param   WP_Post  $post  The current WP_Post object.
 	 *
-	 * @return bool Whether the 'pcc_id' meta-key exists.
+	 * @return bool Whether the 'content_pub_id' meta-key exists.
 	 */
 	protected function isLinkedPost($post)
 	{
-		return (bool) get_post_meta($post->ID, PCC_CONTENT_META_KEY, true);
+		return (bool) get_post_meta($post->ID, CONTENT_PUB_CONTENT_META_KEY, true);
 	}
 
 	/**
 	 * Generates the HTML for the PCC post logo.
 	 *
 	 * This method returns the HTML string for the SVG logo to be displayed
-	 * when the post has the 'pcc_id' meta-key.
+	 * when the post has the 'content_pub_id' meta-key.
 	 *
 	 * @return string The HTML for the SVG logo.
 	 */

--- a/app/PccSiteManager.php
+++ b/app/PccSiteManager.php
@@ -8,9 +8,9 @@ use WP_HTTP_Requests_Response;
 class PccSiteManager
 {
 	private $endpoints = [
-		'create_site' => PCC_ENDPOINT . '/sites',
-		'site' => PCC_ENDPOINT . '/sites/%s',
-		'api_key' => PCC_ENDPOINT . '/api-key',
+		'create_site' => CONTENT_PUB_ENDPOINT . '/sites',
+		'site' => CONTENT_PUB_ENDPOINT . '/sites/%s',
+		'api_key' => CONTENT_PUB_ENDPOINT . '/api-key',
 	];
 
 	/**
@@ -19,7 +19,7 @@ class PccSiteManager
 	 */
 	public function registerWebhook()
 	{
-		$endpoint = sprintf($this->endpoints['site'], get_option(PCC_SITE_ID_OPTION_KEY));
+		$endpoint = sprintf($this->endpoints['site'], get_option(CONTENT_PUB_SITE_ID_OPTION_KEY));
 		$webhookSecret = $this->generateWebhookSecret();
 		$args = [
 			'method' => 'PATCH',
@@ -35,7 +35,7 @@ class PccSiteManager
 		/** @var WP_HTTP_Requests_Response $response */
 		$statusCode = $response['http_response']->get_status();
 		if (204 === intval($statusCode)) {
-			update_option(PCC_WEBHOOK_SECRET_OPTION_KEY, $webhookSecret);
+			update_option(CONTENT_PUB_WEBHOOK_SECRET_OPTION_KEY, $webhookSecret);
 			return true;
 		}
 
@@ -66,7 +66,7 @@ class PccSiteManager
 	 */
 	private function getAccessToken()
 	{
-		return trim(get_option(PCC_ACCESS_TOKEN_OPTION_KEY));
+		return trim(get_option(CONTENT_PUB_ACCESS_TOKEN_OPTION_KEY));
 	}
 
 	/**
@@ -74,7 +74,7 @@ class PccSiteManager
 	 */
 	private function getWebhookEndpoint()
 	{
-		return rest_url(PCC_API_NAMESPACE . '/webhook');
+		return rest_url(CONTENT_PUB_API_NAMESPACE . '/webhook');
 	}
 
 	/**
@@ -134,7 +134,7 @@ class PccSiteManager
 		$args = [
 			'headers' => $this->getHeaders(),
 			'body' => wp_json_encode([
-				'siteId' => get_option(PCC_SITE_ID_OPTION_KEY),
+				'siteId' => get_option(CONTENT_PUB_SITE_ID_OPTION_KEY),
 				'isManagementKey' => false,
 			]),
 		];

--- a/app/PccSyncManager.php
+++ b/app/PccSyncManager.php
@@ -22,8 +22,8 @@ class PccSyncManager
 
 	public function __construct()
 	{
-		$this->siteId = get_option(PCC_SITE_ID_OPTION_KEY);
-		$this->apiKey = get_option(PCC_API_KEY_OPTION_KEY);
+		$this->siteId = get_option(CONTENT_PUB_SITE_ID_OPTION_KEY);
+		$this->apiKey = get_option(CONTENT_PUB_API_KEY_OPTION_KEY);
 	}
 
 	/**
@@ -96,7 +96,7 @@ class PccSyncManager
 	{
 		$args = [
 			'post_type'   => 'any',
-			'meta_key'    => PCC_CONTENT_META_KEY,
+			'meta_key'    => CONTENT_PUB_CONTENT_META_KEY,
 			'meta_value'  => $value,
 			'fields'      => 'ids',
 			'numberposts' => 1,
@@ -133,7 +133,7 @@ class PccSyncManager
 
 		if (!$postId) {
 			$postId = wp_insert_post($data);
-			update_post_meta($postId, PCC_CONTENT_META_KEY, $article->id);
+			update_post_meta($postId, CONTENT_PUB_CONTENT_META_KEY, $article->id);
 			$this->syncPostMetaAndTags($postId, $article);
 			return $postId;
 		}
@@ -213,7 +213,7 @@ class PccSyncManager
 		$imageId = media_sideload_image($featuredImageURL, $postId, null, 'id');
 
 		if (is_int($imageId)) {
-			update_post_meta($imageId, 'pcc_feature_image_url', $featuredImageURL);
+			update_post_meta($imageId, 'content_pub_feature_image_url', $featuredImageURL);
 			// Set as the featured image.
 			set_post_thumbnail($postId, $imageId);
 		}
@@ -229,7 +229,7 @@ class PccSyncManager
 	{
 		$args = [
 			'post_type'  => 'attachment', // Ensure we're looking for attachments.
-			'meta_key'   => 'pcc_feature_image_url',
+			'meta_key'   => 'content_pub_feature_image_url',
 			'meta_value' => $imageUrl,
 			'fields'     => 'ids', // Return only the IDs.
 			'numberposts' => 1,    // Limit to 1 post.
@@ -298,7 +298,7 @@ class PccSyncManager
 	 */
 	private function getIntegrationPostType()
 	{
-		return get_option(PCC_INTEGRATION_POST_TYPE_OPTION_KEY);
+		return get_option(CONTENT_PUB_INTEGRATION_POST_TYPE_OPTION_KEY);
 	}
 
 	/**
@@ -361,12 +361,12 @@ class PccSyncManager
 	 */
 	public function disconnect()
 	{
-		delete_option(PCC_ACCESS_TOKEN_OPTION_KEY);
-		delete_option(PCC_SITE_ID_OPTION_KEY);
-		delete_option(PCC_ENCODED_SITE_URL_OPTION_KEY);
-		delete_option(PCC_INTEGRATION_POST_TYPE_OPTION_KEY);
-		delete_option(PCC_WEBHOOK_SECRET_OPTION_KEY);
-		delete_option(PCC_API_KEY_OPTION_KEY);
+		delete_option(CONTENT_PUB_ACCESS_TOKEN_OPTION_KEY);
+		delete_option(CONTENT_PUB_SITE_ID_OPTION_KEY);
+		delete_option(CONTENT_PUB_ENCODED_SITE_URL_OPTION_KEY);
+		delete_option(CONTENT_PUB_INTEGRATION_POST_TYPE_OPTION_KEY);
+		delete_option(CONTENT_PUB_WEBHOOK_SECRET_OPTION_KEY);
+		delete_option(CONTENT_PUB_API_KEY_OPTION_KEY);
 
 		$this->removeMetaDataFromPosts();
 	}
@@ -379,7 +379,7 @@ class PccSyncManager
 	private function removeMetaDataFromPosts()
 	{
 		// Delete all post meta entries with the key 'terminate'
-		delete_post_meta_by_key(PCC_CONTENT_META_KEY);
+		delete_post_meta_by_key(CONTENT_PUB_CONTENT_META_KEY);
 	}
 
 	/**
@@ -389,10 +389,10 @@ class PccSyncManager
 	 */
 	public function isPCCConfigured(): bool
 	{
-		$accessToken = get_option(PCC_ACCESS_TOKEN_OPTION_KEY);
-		$siteId = get_option(PCC_SITE_ID_OPTION_KEY);
-		$encodedSiteURL = get_option(PCC_ENCODED_SITE_URL_OPTION_KEY);
-		$apiKey = get_option(PCC_API_KEY_OPTION_KEY);
+		$accessToken = get_option(CONTENT_PUB_ACCESS_TOKEN_OPTION_KEY);
+		$siteId = get_option(CONTENT_PUB_SITE_ID_OPTION_KEY);
+		$encodedSiteURL = get_option(CONTENT_PUB_ENCODED_SITE_URL_OPTION_KEY);
+		$apiKey = get_option(CONTENT_PUB_API_KEY_OPTION_KEY);
 
 		if (!$accessToken || !$siteId || !$apiKey || !$encodedSiteURL) {
 			return false;

--- a/app/RestController.php
+++ b/app/RestController.php
@@ -12,7 +12,7 @@ use PccPhpSdk\api\Query\Enums\PublishingLevel;
 
 use function esc_html__;
 
-use const PCC_ACCESS_TOKEN_OPTION_KEY;
+use const CONTENT_PUB_ACCESS_TOKEN_OPTION_KEY;
 
 /**
  * REST controller class.
@@ -83,7 +83,7 @@ class RestController
 		];
 
 		foreach ($endpoints as $endpoint) {
-			register_rest_route(PCC_API_NAMESPACE, $endpoint['route'], [
+			register_rest_route(CONTENT_PUB_API_NAMESPACE, $endpoint['route'], [
 				'methods' => $endpoint['method'],
 				'callback' => $endpoint['callback'],
 				'permission_callback' => [$this, 'permissionCallback'],
@@ -107,7 +107,7 @@ class RestController
 	 */
 	public function handleWebhook(WP_REST_Request $request)
 	{
-		if (get_option(PCC_WEBHOOK_SECRET_OPTION_KEY) !== $request->get_header('x-pcc-webhook-secret')) {
+		if (get_option(CONTENT_PUB_WEBHOOK_SECRET_OPTION_KEY) !== $request->get_header('x-pcc-webhook-secret')) {
 			return new WP_REST_Response(
 				esc_html__('You are not authorized to perform this action', 'pantheon-content-publisher-for-wordpress'),
 				401
@@ -173,8 +173,8 @@ class RestController
 			], 400);
 		}
 
-		update_option(PCC_SITE_ID_OPTION_KEY, $siteId);
-		update_option(PCC_INTEGRATION_POST_TYPE_OPTION_KEY, $postType);
+		update_option(CONTENT_PUB_SITE_ID_OPTION_KEY, $siteId);
+		update_option(CONTENT_PUB_INTEGRATION_POST_TYPE_OPTION_KEY, $postType);
 
 		return new WP_REST_Response(esc_html__('Saved!', 'pantheon-content-publisher-for-wordpress'));
 	}
@@ -190,7 +190,7 @@ class RestController
 			return new WP_REST_Response(esc_html__('You are not authorized to perform this action.', 'pantheon-content-publisher-for-wordpress'), 401);
 		}
 		// Check management token is set
-		if (!get_option(PCC_ACCESS_TOKEN_OPTION_KEY)) {
+		if (!get_option(CONTENT_PUB_ACCESS_TOKEN_OPTION_KEY)) {
 			return new WP_REST_Response(esc_html__('Management token is not set yet', 'pantheon-content-publisher-for-wordpress'), 401);
 		}
 
@@ -201,8 +201,8 @@ class RestController
 		}
 
 		// Update with the site id
-		update_option(PCC_SITE_ID_OPTION_KEY, $response);
-		update_option(PCC_ENCODED_SITE_URL_OPTION_KEY, md5(wp_parse_url(site_url())['host']));
+		update_option(CONTENT_PUB_SITE_ID_OPTION_KEY, $response);
+		update_option(CONTENT_PUB_ENCODED_SITE_URL_OPTION_KEY, md5(wp_parse_url(site_url())['host']));
 		return new WP_REST_Response($response);
 	}
 
@@ -214,12 +214,12 @@ class RestController
 	public function registerWebhook(): WP_REST_Response
 	{
 		// Check management token is set
-		if (!get_option(PCC_ACCESS_TOKEN_OPTION_KEY)) {
+		if (!get_option(CONTENT_PUB_ACCESS_TOKEN_OPTION_KEY)) {
 			return new WP_REST_Response(esc_html__('Management token is not set yet', 'pantheon-content-publisher-for-wordpress'), 400);
 		}
 
 		// Check site id is set
-		if (!get_option(PCC_SITE_ID_OPTION_KEY)) {
+		if (!get_option(CONTENT_PUB_SITE_ID_OPTION_KEY)) {
 			return new WP_REST_Response(esc_html__('Site is not created yet', 'pantheon-content-publisher-for-wordpress'), 400);
 		}
 
@@ -245,7 +245,7 @@ class RestController
 	public function createApiKey(): WP_REST_Response
 	{
 		// Check site id is set
-		if (!get_option(PCC_SITE_ID_OPTION_KEY)) {
+		if (!get_option(CONTENT_PUB_SITE_ID_OPTION_KEY)) {
 			return new WP_REST_Response(esc_html__('Site is not created yet', 'pantheon-content-publisher-for-wordpress'), 400);
 		}
 
@@ -257,7 +257,7 @@ class RestController
 		$siteManager = new PccSiteManager();
 		$apiKey = $siteManager->createSiteApiKey();
 		if ($apiKey) {
-			update_option(PCC_API_KEY_OPTION_KEY, $apiKey);
+			update_option(CONTENT_PUB_API_KEY_OPTION_KEY, $apiKey);
 			return new WP_REST_Response(esc_html__('API created', 'pantheon-content-publisher-for-wordpress'));
 		}
 
@@ -274,12 +274,12 @@ class RestController
 	{
 		$siteId = sanitize_text_field($request->get_param('site_id') ?: '');
 		if ($siteId) {
-			update_option(PCC_SITE_ID_OPTION_KEY, $siteId);
+			update_option(CONTENT_PUB_SITE_ID_OPTION_KEY, $siteId);
 		}
 
 		$postType = sanitize_text_field($request->get_param('post_type') ?: '');
 		if ($postType) {
-			update_option(PCC_INTEGRATION_POST_TYPE_OPTION_KEY, $postType);
+			update_option(CONTENT_PUB_INTEGRATION_POST_TYPE_OPTION_KEY, $postType);
 		}
 
 		return new WP_REST_Response(esc_html__('Saved!', 'pantheon-content-publisher-for-wordpress'));
@@ -308,7 +308,7 @@ class RestController
 			);
 		}
 
-		update_option(PCC_ACCESS_TOKEN_OPTION_KEY, $accessToken);
+		update_option(CONTENT_PUB_ACCESS_TOKEN_OPTION_KEY, $accessToken);
 		return new WP_REST_Response(
 			esc_html__('Management token saved.', 'pantheon-content-publisher-for-wordpress'),
 			200

--- a/app/Settings.php
+++ b/app/Settings.php
@@ -18,10 +18,10 @@ use function get_post_meta;
 use function wp_enqueue_script;
 use function wp_strip_all_tags;
 
-use const PCC_CONTENT_META_KEY;
-use const PCC_INTEGRATION_POST_TYPE_OPTION_KEY;
-use const PCC_PLUGIN_DIR;
-use const PCC_PLUGIN_DIR_URL;
+use const CONTENT_PUB_CONTENT_META_KEY;
+use const CONTENT_PUB_INTEGRATION_POST_TYPE_OPTION_KEY;
+use const CONTENT_PUB_PLUGIN_DIR;
+use const CONTENT_PUB_PLUGIN_DIR_URL;
 
 // phpcs:disable PSR1.Files.SideEffects.FoundWithSymbols
 
@@ -35,28 +35,28 @@ class Settings
 	 * Pantheon menu icon in base64
 	 */
 	// phpcs:ignore Generic.Files.LineLength.TooLong
-	private const PCC_ICON_BASE64 = 'PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIHZpZXdCb3g9IjAgMCAxNiAxNiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICAgIDxwYXRoIGQ9Ik00LjcxNjkxIDFMNi4xNTA3MSA0LjQ1NDE4SDQuMzI1ODdMNC45MTI0MiA1Ljk1MzE2SDguNjI3MjlMNC43MTY5MSAxWiIgZmlsbD0id2hpdGUiLz4KICAgIDxwYXRoIGQ9Ik05LjU3MjI5IDEzLjU0NThMOC45NTMxNCAxMi4wNDY5SDguMTA1ODlMNi4zNDYyMiA3Ljc3ODAySDUuNTk2NzNMNy4zNTY0IDEyLjA0NjlINS4yMDU2OUw5LjE4MTI1IDE3TDcuNzQ3NDQgMTMuNTQ1OEg5LjU3MjI5WiIKICAgICAgICAgIGZpbGw9IndoaXRlIi8+CiAgICA8cGF0aCBkPSJNMTAuMDYxMSAxMC41MTUzSDcuNzQ3NDRMOC4yMzYyNCAxMS42ODg0SDEwLjA2MTFDMTAuMDkzNyAxMS42ODg0IDEwLjIyNCAxMS42MjMyIDEwLjIyNCAxMS4xMDE4QzEwLjE5MTQgMTAuNTgwNCAxMC4wOTM3IDEwLjUxNTMgMTAuMDYxMSAxMC41MTUzWiIKICAgICAgICAgIGZpbGw9IndoaXRlIi8+CiAgICA8cGF0aCBkPSJNMTAuMjg5MiA5LjExNDA0SDcuMTkzNDhMNy42ODIyOCAxMC4yODcySDEwLjI4OTJDMTAuMzIxOCAxMC4yODcyIDEwLjQ1MjEgMTAuMjIyIDEwLjQ1MjEgOS43MDA2QzEwLjQxOTYgOS4xNzkyMiAxMC4zMjE4IDkuMTE0MDQgMTAuMjg5MiA5LjExNDA0WiIKICAgICAgICAgIGZpbGw9IndoaXRlIi8+CiAgICA8cGF0aCBkPSJNMTAuMDYxMSA3LjQ4NDczQzEwLjA5MzcgNy40ODQ3MyAxMC4yMjQgNy40MTk1NiAxMC4yMjQgNi44OTgxN0MxMC4yMjQgNi4zNzY3OSAxMC4xMjYzIDYuMzExNjEgMTAuMDYxMSA2LjMxMTYxSDcuNTE5MzVMOC4wMDgxNSA3LjQ4NDczSDEwLjA2MTFaIgogICAgICAgICAgZmlsbD0id2hpdGUiLz4KICAgIDxwYXRoIGQ9Ik04LjU2MjEgOC44ODU5NUgxMC4yNTY2QzEwLjI4OTIgOC44ODU5NSAxMC40MTk1IDguODIwNzcgMTAuNDE5NSA4LjI5OTM5QzEwLjQxOTUgNy43NzggMTAuMzIxOCA3LjcxMjgzIDEwLjI1NjYgNy43MTI4M0g4LjA3MzNMOC41NjIxIDguODg1OTVaIgogICAgICAgICAgZmlsbD0id2hpdGUiLz4KICAgIDxwYXRoIGQ9Ik01Ljc1OTY3IDguODg1OTVMNS4yMDU3IDcuNDg0NzNINi40NzY1OEw3LjA2MzE0IDguODg1OTVIOC4yNjg4NEw3LjE5MzQ4IDYuMzExNjFINC41NTM5N0M0LjM1ODQ1IDYuMzExNjEgNC4yMjgxMSA2LjMxMTYxIDQuMTMwMzUgNi42MDQ4OUM0LjAzMjU5IDYuOTYzMzUgNCA3LjY0NzY2IDQgOC45ODM3MUM0IDEwLjMxOTggNCAxMS4wMDQxIDQuMTMwMzUgMTEuMzYyNUM0LjIyODExIDExLjY1NTggNC4zMjU4NyAxMS42NTU4IDQuNTUzOTcgMTEuNjU1OEg2Ljg2NzYyTDUuNzU5NjcgOC44ODU5NVoiCiAgICAgICAgICBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4=';
+	private const CONTENT_PUB_ICON_BASE64 = 'PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIHZpZXdCb3g9IjAgMCAxNiAxNiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICAgIDxwYXRoIGQ9Ik00LjcxNjkxIDFMNi4xNTA3MSA0LjQ1NDE4SDQuMzI1ODdMNC45MTI0MiA1Ljk1MzE2SDguNjI3MjlMNC43MTY5MSAxWiIgZmlsbD0id2hpdGUiLz4KICAgIDxwYXRoIGQ9Ik05LjU3MjI5IDEzLjU0NThMOC45NTMxNCAxMi4wNDY5SDguMTA1ODlMNi4zNDYyMiA3Ljc3ODAySDUuNTk2NzNMNy4zNTY0IDEyLjA0NjlINS4yMDU2OUw5LjE4MTI1IDE3TDcuNzQ3NDQgMTMuNTQ1OEg5LjU3MjI5WiIKICAgICAgICAgIGZpbGw9IndoaXRlIi8+CiAgICA8cGF0aCBkPSJNMTAuMDYxMSAxMC41MTUzSDcuNzQ3NDRMOC4yMzYyNCAxMS42ODg0SDEwLjA2MTFDMTAuMDkzNyAxMS42ODg0IDEwLjIyNCAxMS42MjMyIDEwLjIyNCAxMS4xMDE4QzEwLjE5MTQgMTAuNTgwNCAxMC4wOTM3IDEwLjUxNTMgMTAuMDYxMSAxMC41MTUzWiIKICAgICAgICAgIGZpbGw9IndoaXRlIi8+CiAgICA8cGF0aCBkPSJNMTAuMjg5MiA5LjExNDA0SDcuMTkzNDhMNy42ODIyOCAxMC4yODcySDEwLjI4OTJDMTAuMzIxOCAxMC4yODcyIDEwLjQ1MjEgMTAuMjIyIDEwLjQ1MjEgOS43MDA2QzEwLjQxOTYgOS4xNzkyMiAxMC4zMjE4IDkuMTE0MDQgMTAuMjg5MiA5LjExNDA0WiIKICAgICAgICAgIGZpbGw9IndoaXRlIi8+CiAgICA8cGF0aCBkPSJNMTAuMDYxMSA3LjQ4NDczQzEwLjA5MzcgNy40ODQ3MyAxMC4yMjQgNy40MTk1NiAxMC4yMjQgNi44OTgxN0MxMC4yMjQgNi4zNzY3OSAxMC4xMjYzIDYuMzExNjEgMTAuMDYxMSA2LjMxMTYxSDcuNTE5MzVMOC4wMDgxNSA3LjQ4NDczSDEwLjA2MTFaIgogICAgICAgICAgZmlsbD0id2hpdGUiLz4KICAgIDxwYXRoIGQ9Ik04LjU2MjEgOC44ODU5NUgxMC4yNTY2QzEwLjI4OTIgOC44ODU5NSAxMC40MTk1IDguODIwNzcgMTAuNDE5NSA4LjI5OTM5QzEwLjQxOTUgNy43NzggMTAuMzIxOCA3LjcxMjgzIDEwLjI1NjYgNy43MTI4M0g4LjA3MzNMOC41NjIxIDguODg1OTVaIgogICAgICAgICAgZmlsbD0id2hpdGUiLz4KICAgIDxwYXRoIGQ9Ik01Ljc1OTY3IDguODg1OTVMNS4yMDU3IDcuNDg0NzNINi40NzY1OEw3LjA2MzE0IDguODg1OTVIOC4yNjg4NEw3LjE5MzQ4IDYuMzExNjFINC41NTM5N0M0LjM1ODQ1IDYuMzExNjEgNC4yMjgxMSA2LjMxMTYxIDQuMTMwMzUgNi42MDQ4OUM0LjAzMjU5IDYuOTYzMzUgNCA3LjY0NzY2IDQgOC45ODM3MUM0IDEwLjMxOTggNCAxMS4wMDQxIDQuMTMwMzUgMTEuMzYyNUM0LjIyODExIDExLjY1NTggNC4zMjU4NyAxMS42NTU4IDQuNTUzOTcgMTEuNjU1OEg2Ljg2NzYyTDUuNzU5NjcgOC44ODU5NVoiCiAgICAgICAgICBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4=';
 
 	/**
 	 * Pantheon Cloud Status endpoint required by PCC
 	 */
-	private const PCC_STATUS_ENDPOINT = 'api/pantheoncloud/status';
+	private const CONTENT_PUB_STATUS_ENDPOINT = 'api/pantheoncloud/status';
 
 	/**
 	 * Publish document endpoint required by PCC
 	 */
-	private const PCC_PUBLISH_DOCUMENT_ENDPOINT = 'api/pantheoncloud/document/';
+	private const CONTENT_PUB_PUBLISH_DOCUMENT_ENDPOINT = 'api/pantheoncloud/document/';
 
 	/**
 	 * Google Docs edit URL.
 	 */
-	private const PCC_DOCUMENT_EDIT_URL = 'https://docs.google.com/document/d/%s/edit';
+	private const CONTENT_PUB_DOCUMENT_EDIT_URL = 'https://docs.google.com/document/d/%s/edit';
 
 	private $pages = [
-		'connected-collection' => PCC_PLUGIN_DIR . 'admin/templates/partials/connected-collection.php',
-		'create-collection' => PCC_PLUGIN_DIR . 'admin/templates/partials/create-collection.php',
-		'disconnect-confirmation' => PCC_PLUGIN_DIR . 'admin/templates/partials/disconnect-confirmation.php',
-		'setup' => PCC_PLUGIN_DIR . 'admin/templates/partials/setup.php',
+		'connected-collection' => CONTENT_PUB_PLUGIN_DIR . 'admin/templates/partials/connected-collection.php',
+		'create-collection' => CONTENT_PUB_PLUGIN_DIR . 'admin/templates/partials/create-collection.php',
+		'disconnect-confirmation' => CONTENT_PUB_PLUGIN_DIR . 'admin/templates/partials/disconnect-confirmation.php',
+		'setup' => CONTENT_PUB_PLUGIN_DIR . 'admin/templates/partials/setup.php',
 	];
 
 	public function __construct()
@@ -103,7 +103,7 @@ class Settings
 	 */
 	public function stripExcerptTags(string $content): string
 	{
-		if (get_post_meta(get_the_ID(), PCC_CONTENT_META_KEY, true)) {
+		if (get_post_meta(get_the_ID(), CONTENT_PUB_CONTENT_META_KEY, true)) {
 			return wp_strip_all_tags($content);
 		}
 
@@ -119,7 +119,7 @@ class Settings
 	{
 		$accessToken = $this->getAccessToken();
 		$siteId = $this->getSiteId();
-		$encodedSiteURL = get_option(PCC_ENCODED_SITE_URL_OPTION_KEY);
+		$encodedSiteURL = get_option(CONTENT_PUB_ENCODED_SITE_URL_OPTION_KEY);
 		$apiKey = $this->getAPIAccessKey();
 
 		if (!$accessToken || !$siteId || !$apiKey || !$encodedSiteURL) {
@@ -141,7 +141,7 @@ class Settings
 	 */
 	private function getAccessToken(): mixed
 	{
-		$pccToken = get_option(PCC_ACCESS_TOKEN_OPTION_KEY);
+		$pccToken = get_option(CONTENT_PUB_ACCESS_TOKEN_OPTION_KEY);
 
 		return $pccToken ?: [];
 	}
@@ -151,7 +151,7 @@ class Settings
 	 */
 	private function getSiteId(): mixed
 	{
-		return get_option(PCC_SITE_ID_OPTION_KEY);
+		return get_option(CONTENT_PUB_SITE_ID_OPTION_KEY);
 	}
 
 	/**
@@ -161,7 +161,7 @@ class Settings
 	 */
 	private function getAPIAccessKey(): mixed
 	{
-		$apiKey = get_option(PCC_API_KEY_OPTION_KEY);
+		$apiKey = get_option(CONTENT_PUB_API_KEY_OPTION_KEY);
 
 		return $apiKey ?: [];
 	}
@@ -192,7 +192,7 @@ class Settings
 	 */
 	public function allowStyleTags($allowedTags)
 	{
-		if (get_post_meta(get_the_ID(), PCC_CONTENT_META_KEY, true)) {
+		if (get_post_meta(get_the_ID(), CONTENT_PUB_CONTENT_META_KEY, true)) {
 				$allowedTags['style'] = [];
 		}
 
@@ -207,7 +207,7 @@ class Settings
 	public function publishDocuments(): void
 	{
 		global $wp;
-		if (!str_starts_with($wp->request, static::PCC_PUBLISH_DOCUMENT_ENDPOINT)) {
+		if (!str_starts_with($wp->request, static::CONTENT_PUB_PUBLISH_DOCUMENT_ENDPOINT)) {
 			return;
 		}
 
@@ -328,8 +328,8 @@ class Settings
 	public function registerPantheonCloudStatusEndpoint()
 	{
 		global $wp;
-		if (static::PCC_STATUS_ENDPOINT === $wp->request) {
-			$url = rest_url(PCC_API_NAMESPACE . '/' . static::PCC_STATUS_ENDPOINT);
+		if (static::CONTENT_PUB_STATUS_ENDPOINT === $wp->request) {
+			$url = rest_url(CONTENT_PUB_API_NAMESPACE . '/' . static::CONTENT_PUB_STATUS_ENDPOINT);
 
 			return wp_redirect($url);
 		}
@@ -442,7 +442,7 @@ class Settings
 	 */
 	private function buildEditDocumentURL(string $documentId): string
 	{
-		return sprintf(self::PCC_DOCUMENT_EDIT_URL, $documentId);
+		return sprintf(self::CONTENT_PUB_DOCUMENT_EDIT_URL, $documentId);
 	}
 
 	/**
@@ -476,7 +476,7 @@ class Settings
 	 */
 	public function addRowActions($actions, $post): mixed
 	{
-		$documentId = get_post_meta($post->ID, PCC_CONTENT_META_KEY, true);
+		$documentId = get_post_meta($post->ID, CONTENT_PUB_CONTENT_META_KEY, true);
 		if (!$documentId) {
 			return $actions;
 		}
@@ -529,7 +529,7 @@ class Settings
 	 */
 	public function pccMenuIcon(): string
 	{
-		return 'data:image/svg+xml;base64,' . self::PCC_ICON_BASE64;
+		return 'data:image/svg+xml;base64,' . self::CONTENT_PUB_ICON_BASE64;
 	}
 
 	/**
@@ -570,24 +570,24 @@ class Settings
 	{
 		wp_enqueue_script(
 			'pantheon-content-publisher-for-wordpress',
-			PCC_PLUGIN_DIR_URL . 'dist/app.js',
+			CONTENT_PUB_PLUGIN_DIR_URL . 'dist/app.js',
 			[],
-			filemtime(PCC_PLUGIN_DIR . 'dist/app.js'),
+			filemtime(CONTENT_PUB_PLUGIN_DIR . 'dist/app.js'),
 			true
 		);
 
 		wp_enqueue_style(
 			'pantheon-content-publisher-for-wordpress',
-			PCC_PLUGIN_DIR_URL . 'dist/app.css',
+			CONTENT_PUB_PLUGIN_DIR_URL . 'dist/app.css',
 			[],
-			filemtime(PCC_PLUGIN_DIR . 'dist/app.css')
+			filemtime(CONTENT_PUB_PLUGIN_DIR . 'dist/app.css')
 		);
 
 		wp_localize_script(
 			'pantheon-content-publisher-for-wordpress',
 			'PCCAdmin',
 			[
-				'rest_url' => get_rest_url(get_current_blog_id(), PCC_API_NAMESPACE),
+				'rest_url' => get_rest_url(get_current_blog_id(), CONTENT_PUB_API_NAMESPACE),
 				'nonce' => wp_create_nonce('wp_rest'),
 				'plugin_main_page' => menu_page_url('pantheon-content-publisher-for-wordpress', false),
 				'site_url' => site_url(),
@@ -611,9 +611,9 @@ class Settings
 
 		wp_enqueue_script(
 			'pantheon-content-publisher-for-wordpress',
-			PCC_PLUGIN_DIR_URL . 'dist/pcc-front.js',
+			CONTENT_PUB_PLUGIN_DIR_URL . 'dist/pcc-front.js',
 			[],
-			filemtime(PCC_PLUGIN_DIR . 'dist/pcc-front.js'),
+			filemtime(CONTENT_PUB_PLUGIN_DIR . 'dist/pcc-front.js'),
 			true
 		);
 
@@ -647,7 +647,7 @@ class Settings
 	 */
 	public function pluginNotification()
 	{
-		require PCC_PLUGIN_DIR . 'admin/templates/partials/plugin-notification.php';
+		require CONTENT_PUB_PLUGIN_DIR . 'admin/templates/partials/plugin-notification.php';
 	}
 
 	/**
@@ -671,6 +671,6 @@ class Settings
 	 */
 	private function getEncodedSiteURL(): mixed
 	{
-		return get_option(PCC_ENCODED_SITE_URL_OPTION_KEY);
+		return get_option(CONTENT_PUB_ENCODED_SITE_URL_OPTION_KEY);
 	}
 }

--- a/pantheon-content-publisher-for-wordpress.php
+++ b/pantheon-content-publisher-for-wordpress.php
@@ -20,19 +20,19 @@ if (!\defined('ABSPATH')) {
 	exit;
 }
 
-define('PCC_PLUGIN_FILE', __FILE__);
-define('PCC_PLUGIN_DIR', plugin_dir_path(PCC_PLUGIN_FILE));
-define('PCC_BASENAME', plugin_basename(PCC_PLUGIN_FILE));
-define('PCC_PLUGIN_DIR_URL', plugin_dir_url(PCC_PLUGIN_FILE));
-define('PCC_ACCESS_TOKEN_OPTION_KEY', 'pcc_access_token');
-define('PCC_SITE_ID_OPTION_KEY', 'pcc_site_id');
-define('PCC_ENCODED_SITE_URL_OPTION_KEY', 'pcc_encoded_site_url');
-define('PCC_API_KEY_OPTION_KEY', 'pcc_api_key');
-define('PCC_INTEGRATION_POST_TYPE_OPTION_KEY', 'pcc_integration_post_type');
-define('PCC_API_NAMESPACE', 'pcc/v1');
-define('PCC_CONTENT_META_KEY', 'pcc_id');
-define('PCC_ENDPOINT', 'https://addonapi-gfttxsojwq-uc.a.run.app');
-define('PCC_WEBHOOK_SECRET_OPTION_KEY', 'pcc_webhook_secret');
+define('CONTENT_PUB_PLUGIN_FILE', __FILE__);
+define('CONTENT_PUB_PLUGIN_DIR', plugin_dir_path(CONTENT_PUB_PLUGIN_FILE));
+define('CONTENT_PUB_BASENAME', plugin_basename(CONTENT_PUB_PLUGIN_FILE));
+define('CONTENT_PUB_PLUGIN_DIR_URL', plugin_dir_url(CONTENT_PUB_PLUGIN_FILE));
+define('CONTENT_PUB_ACCESS_TOKEN_OPTION_KEY', 'content_pub_access_token');
+define('CONTENT_PUB_SITE_ID_OPTION_KEY', 'content_pub_site_id');
+define('CONTENT_PUB_ENCODED_SITE_URL_OPTION_KEY', 'content_pub_encoded_site_url');
+define('CONTENT_PUB_API_KEY_OPTION_KEY', 'content_pub_api_key');
+define('CONTENT_PUB_INTEGRATION_POST_TYPE_OPTION_KEY', 'content_pub_integration_post_type');
+define('CONTENT_PUB_API_NAMESPACE', 'pcc/v1');
+define('CONTENT_PUB_CONTENT_META_KEY', 'content_pub_id');
+define('CONTENT_PUB_ENDPOINT', 'https://addonapi-gfttxsojwq-uc.a.run.app');
+define('CONTENT_PUB_WEBHOOK_SECRET_OPTION_KEY', 'content_pub_webhook_secret');
 
 call_user_func(static function ($rootPath) {
 	$autoload = "{$rootPath}vendor/autoload.php";
@@ -40,4 +40,4 @@ call_user_func(static function ($rootPath) {
 		require_once $autoload;
 	}
 	add_action('plugins_loaded', [Plugin::class, 'getInstance'], -10);
-}, PCC_PLUGIN_DIR);
+}, CONTENT_PUB_PLUGIN_DIR);


### PR DESCRIPTION
To meet WordPress standard for validation, we are updating the functions, namespaces, defines, classes and option names with a new prefix.
Whatever was starting with ppc_ is now using prefix content_pub_

The only prefixes I haven't changed are in the HTML and CSS files in the assets folder. They are not necessary for the plugin's functioning or its relation with Pantheon Content Cloud. 

## Testing instructions
You can use the plugin as usual; no errors or connection issues should be caused. 

## Checklist:

- [x] I've tested the code.
- [x] My code follows the repository code
  style. <!-- Ruleset: https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress/blob/primary/phpcs.xml/ -->
- [x] My code follows the accessibility
  standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the PHP DocBlock documentation
  standards. <!-- Resource: https://docs.phpdoc.org/guides/docblocks.html -->
