### PR TITLE
[SITE-4827] Remove core files call and fails silently instead

### DIFF
--- a/app/PccSyncManager.php
+++ b/app/PccSyncManager.php
@@ -208,9 +208,8 @@ class PccSyncManager
 
 		// Ensure media_sideload_image function is available.
 		if (!function_exists('media_sideload_image')) {
-			require_once(ABSPATH . 'wp-admin/includes/media.php');
-			require_once(ABSPATH . 'wp-admin/includes/file.php');
-			require_once(ABSPATH . 'wp-admin/includes/image.php');
+			// has to fail silently
+			return;
 		}
 
 		// Download and attach the new image.
@@ -253,6 +252,8 @@ class PccSyncManager
 	 */
 	private function findArticleCategories(Article $article): array
 	{
+		// TODO: actually get the categories from the Google Doc Form
+		// Right now, it's empty
 		$categories = $article->metadata['Categories'] ? explode(',', (string) $article->metadata['Categories']) : [];
 		$categories = array_filter($categories);
 		if (!$categories) {
@@ -274,7 +275,8 @@ class PccSyncManager
 	{
 		$ids = [];
 		if (!function_exists('wp_insert_category')) {
-			require_once(ABSPATH . 'wp-admin/includes/taxonomy.php');
+			// has to fail silently
+			return $ids;
 		}
 
 		foreach ($categories as $category) {


### PR DESCRIPTION
## Description

Calling core files like wp-config.php is not permitted. To adhere to the WordPress criteria, the calls have been removed and are falling silently if the function does not exist. 

No categories are being passed from the Google Drive form. The findOrCreateFunction was already not being called. 

## Testing instructions
Post a post or article from your Google Drive to your WordPress site. 
No error should come up whether the image is being saved or not. 

## Checklist:

- [x] I've tested the code.
- [x] My code follows the repository code
  style. <!-- Ruleset: https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress/blob/primary/phpcs.xml/ -->
- [x] My code follows the accessibility
  standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the PHP DocBlock documentation
  standards. <!-- Resource: https://docs.phpdoc.org/guides/docblocks.html -->
