### PR TITLE
[SITE-4831] Removes backsplash in the if condition

### DIFF
--- a/admin/templates/partials/connected-collection.php
+++ b/admin/templates/partials/connected-collection.php
@@ -1,6 +1,6 @@
 <?php
 // Exit if accessed directly.
-if (!\defined('ABSPATH')) {
+if (!defined('ABSPATH')) {
 	exit;
 }
 ?>

--- a/admin/templates/partials/create-collection.php
+++ b/admin/templates/partials/create-collection.php
@@ -1,6 +1,6 @@
 <?php
 // Exit if accessed directly.
-if (!\defined('ABSPATH')) {
+if (!defined('ABSPATH')) {
 	exit;
 }
 ?>

--- a/admin/templates/partials/disconnect-confirmation.php
+++ b/admin/templates/partials/disconnect-confirmation.php
@@ -1,6 +1,6 @@
 <?php
 // Exit if accessed directly.
-if (!\defined('ABSPATH')) {
+if (!defined('ABSPATH')) {
 	exit;
 }
 ?>

--- a/admin/templates/partials/error-message.php
+++ b/admin/templates/partials/error-message.php
@@ -1,6 +1,6 @@
 <?php
 // Exit if accessed directly.
-if (!\defined('ABSPATH')) {
+if (!defined('ABSPATH')) {
 	exit;
 }
 ?>

--- a/admin/templates/partials/footer.php
+++ b/admin/templates/partials/footer.php
@@ -1,6 +1,6 @@
 <?php
 // Exit if accessed directly.
-if (!\defined('ABSPATH')) {
+if (!defined('ABSPATH')) {
 	exit;
 }
 ?>

--- a/admin/templates/partials/header.php
+++ b/admin/templates/partials/header.php
@@ -1,6 +1,6 @@
 <?php
 // Exit if accessed directly.
-if (!\defined('ABSPATH')) {
+if (!defined('ABSPATH')) {
 	exit;
 }
 ?>

--- a/admin/templates/partials/plugin-notification.php
+++ b/admin/templates/partials/plugin-notification.php
@@ -1,6 +1,6 @@
 <?php
 // Exit if accessed directly.
-if (!\defined('ABSPATH')) {
+if (!defined('ABSPATH')) {
 	exit;
 }
 ?>

--- a/admin/templates/partials/setup.php
+++ b/admin/templates/partials/setup.php
@@ -1,6 +1,6 @@
 <?php
 // Exit if accessed directly.
-if (!\defined('ABSPATH')) {
+if (!defined('ABSPATH')) {
 	exit;
 }
 ?>

--- a/admin/templates/partials/spinner.php
+++ b/admin/templates/partials/spinner.php
@@ -1,6 +1,6 @@
 <?php
 // Exit if accessed directly.
-if (!\defined('ABSPATH')) {
+if (!defined('ABSPATH')) {
 	exit;
 }
 ?>

--- a/app/PccSyncManager.php
+++ b/app/PccSyncManager.php
@@ -40,7 +40,7 @@ class PccSyncManager
 		$documentId,
 		PublishingLevel $publishingLevel,
 		bool $isDraft = false,
-		PccClient $pccClient = null,
+		?PccClient $pccClient = null,
 		?string $versionId = null
 	): int {
 		$articlesApi = new ArticlesApi($pccClient ?? $this->pccClient());
@@ -68,7 +68,7 @@ class PccSyncManager
 	 * @param string|null $pccGrant
 	 * @return PccClient
 	 */
-	public function pccClient(string $pccGrant = null): PccClient
+	public function pccClient(?string $pccGrant = null): PccClient
 	{
 		$args = [$this->siteId, $this->apiKey];
 		if ($pccGrant) {


### PR DESCRIPTION
## Description
To pass the WordPress plugin validation, use the conventional approach to disallow direct file access to plugin files.
Also, a tiny fix on declaring a parameter to null, deprecated in PHP 8.4

## Testing instructions
Those files affect the layout on the Plugin's WordPress admin page. 

Could you add the plugin to your site?
Connect to the Google add-on.
Create a Google Drive and connect your document to your WordPress site
Publish to your site
Check for errors in the process, logs and elsewhere.
No errors or unexpected behaviours should occur in the publishing process. 

## Checklist:

- [x] I've tested the code.
- [x] My code follows the repository code
  style. <!-- Ruleset: https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress/blob/primary/phpcs.xml/ -->
- [x] My code follows the accessibility
  standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the PHP DocBlock documentation
  standards. <!-- Resource: https://docs.phpdoc.org/guides/docblocks.html -->
